### PR TITLE
Integrate ESLint and beef up Travis CI configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+	"extends": [
+		"plugin:prettier/recommended",
+		"react-app",
+		"plugin:jsx-a11y/recommended"
+	],
+	"plugins": ["jsx-a11y"]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,40 @@
 language: node_js
-node_js:
-  - 8
 cache:
   directories:
     - node_modules
-script:
-  - npm install -g codecov
-  - npm run build
-  - npm test -- --coverage
-  - codecov
+branches:
+  only:
+    - master
+jobs:
+  include:
+    - stage: test
+      if: type = pull_request
+      name: Lint code
+      node_js: lts/*
+      script:
+        - npx eslint .
+    - stage: test
+      if: type = pull_request
+      name: Verify build
+      node_js: lts/*
+      script:
+        - npm run build
+    - stage: test
+      if: type = pull_request
+      name: Run tests
+      node_js: lts/*
+      script:
+        - npm install -g codecov
+        - npm test -- --coverage
+        - codecov
+    - stage: deploy
+      if: type = push
+      name: Deploy to GitHub Pages
+      deploy:
+        provider: pages
+        local_dir: build
+        skip_cleanup: true
+        github_token: $GITHUB_TOKEN
+        keep_history: true
+        on:
+          branch: master

--- a/package-lock.json
+++ b/package-lock.json
@@ -4856,6 +4856,23 @@
 				}
 			}
 		},
+		"eslint-config-prettier": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.3.0.tgz",
+			"integrity": "sha512-EWaGjlDAZRzVFveh2Jsglcere2KK5CJBhkNSa1xs3KfMUGdRiT7lG089eqPdvlzWHpAqaekubOsOMu8W8Yk71A==",
+			"dev": true,
+			"requires": {
+				"get-stdin": "^6.0.0"
+			},
+			"dependencies": {
+				"get-stdin": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+					"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+					"dev": true
+				}
+			}
+		},
 		"eslint-config-react-app": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-5.0.2.tgz",
@@ -5133,6 +5150,15 @@
 				"emoji-regex": "^7.0.2",
 				"has": "^1.0.3",
 				"jsx-ast-utils": "^2.2.1"
+			}
+		},
+		"eslint-plugin-prettier": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.1.tgz",
+			"integrity": "sha512-A+TZuHZ0KU0cnn56/9mfR7/KjUJ9QNVXUhwvRFSR7PGPe0zQR6PTkmyqg1AtUUEOzTqeRsUwyKFh0oVZKVCrtA==",
+			"dev": true,
+			"requires": {
+				"prettier-linter-helpers": "^1.0.0"
 			}
 		},
 		"eslint-plugin-react": {
@@ -5512,6 +5538,12 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
 			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+		},
+		"fast-diff": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+			"dev": true
 		},
 		"fast-glob": {
 			"version": "2.2.7",
@@ -10951,6 +10983,15 @@
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
 			"integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
 			"dev": true
+		},
+		"prettier-linter-helpers": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+			"integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+			"dev": true,
+			"requires": {
+				"fast-diff": "^1.1.2"
+			}
 		},
 		"pretty-bytes": {
 			"version": "5.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1153,47 +1153,10 @@
 				"glob-to-regexp": "^0.3.0"
 			}
 		},
-		"@nodelib/fs.scandir": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.2.tgz",
-			"integrity": "sha512-wrIBsjA5pl13f0RN4Zx4FNWmU71lv03meGKnqRUoCyan17s4V3WL92f3w3AIuWbNnpcrQyFBU5qMavJoB8d27w==",
-			"dev": true,
-			"requires": {
-				"@nodelib/fs.stat": "2.0.2",
-				"run-parallel": "^1.1.9"
-			},
-			"dependencies": {
-				"@nodelib/fs.stat": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.2.tgz",
-					"integrity": "sha512-z8+wGWV2dgUhLqrtRYa03yDx4HWMvXKi1z8g3m2JyxAx8F7xk74asqPk5LAETjqDSGLFML/6CDl0+yFunSYicw==",
-					"dev": true
-				}
-			}
-		},
 		"@nodelib/fs.stat": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
 			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
-		},
-		"@nodelib/fs.walk": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.3.tgz",
-			"integrity": "sha512-l6t8xEhfK9Sa4YO5mIRdau7XSOADfmh3jCr0evNHdY+HNkW6xuQhgMH7D73VV6WpZOagrW0UludvMTiifiwTfA==",
-			"dev": true,
-			"requires": {
-				"@nodelib/fs.scandir": "2.1.2",
-				"fastq": "^1.6.0"
-			}
-		},
-		"@samverschueren/stream-to-observable": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
-			"integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
-			"dev": true,
-			"requires": {
-				"any-observable": "^0.3.0"
-			}
 		},
 		"@svgr/babel-plugin-add-jsx-attribute": {
 			"version": "4.2.0",
@@ -1346,23 +1309,6 @@
 			"resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
 			"integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag=="
 		},
-		"@types/events": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
-			"dev": true
-		},
-		"@types/glob": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-			"integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
-			"dev": true,
-			"requires": {
-				"@types/events": "*",
-				"@types/minimatch": "*",
-				"@types/node": "*"
-			}
-		},
 		"@types/istanbul-lib-coverage": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -1403,22 +1349,10 @@
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
 			"integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A=="
 		},
-		"@types/minimatch": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-			"dev": true
-		},
 		"@types/node": {
 			"version": "12.7.5",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
 			"integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w=="
-		},
-		"@types/normalize-package-data": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-			"integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
-			"dev": true
 		},
 		"@types/prop-types": {
 			"version": "15.7.2",
@@ -1746,16 +1680,6 @@
 				}
 			}
 		},
-		"aggregate-error": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.0.tgz",
-			"integrity": "sha512-yKD9kEoJIR+2IFqhMwayIBgheLYbB3PS2OBhWae1L/ODTd/JF/30cW0bc9TqzRL3k4U41Dieu3BF4I29p8xesA==",
-			"dev": true,
-			"requires": {
-				"clean-stack": "^2.0.0",
-				"indent-string": "^3.2.0"
-			}
-		},
 		"airbnb-prop-types": {
 			"version": "2.15.0",
 			"resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.15.0.tgz",
@@ -1826,12 +1750,6 @@
 			"requires": {
 				"color-convert": "^1.9.0"
 			}
-		},
-		"any-observable": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
-			"integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
-			"dev": true
 		},
 		"anymatch": {
 			"version": "2.0.0",
@@ -2841,22 +2759,26 @@
 					"dependencies": {
 						"abbrev": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+							"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 							"optional": true
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 							"optional": true
 						},
 						"aproba": {
 							"version": "1.2.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 							"optional": true
 						},
 						"are-we-there-yet": {
 							"version": "1.1.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+							"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 							"optional": true,
 							"requires": {
 								"delegates": "^1.0.0",
@@ -2865,12 +2787,14 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+							"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 							"optional": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+							"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
@@ -2879,32 +2803,38 @@
 						},
 						"chownr": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+							"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
 							"optional": true
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+							"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 							"optional": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+							"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 							"optional": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+							"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 							"optional": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+							"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 							"optional": true
 						},
 						"debug": {
 							"version": "4.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+							"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 							"optional": true,
 							"requires": {
 								"ms": "^2.1.1"
@@ -2912,22 +2842,26 @@
 						},
 						"deep-extend": {
 							"version": "0.6.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+							"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 							"optional": true
 						},
 						"delegates": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+							"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 							"optional": true
 						},
 						"detect-libc": {
 							"version": "1.0.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+							"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 							"optional": true
 						},
 						"fs-minipass": {
 							"version": "1.2.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+							"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
 							"optional": true,
 							"requires": {
 								"minipass": "^2.2.1"
@@ -2935,12 +2869,14 @@
 						},
 						"fs.realpath": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+							"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 							"optional": true
 						},
 						"gauge": {
 							"version": "2.7.4",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+							"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 							"optional": true,
 							"requires": {
 								"aproba": "^1.0.3",
@@ -2955,7 +2891,8 @@
 						},
 						"glob": {
 							"version": "7.1.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+							"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 							"optional": true,
 							"requires": {
 								"fs.realpath": "^1.0.0",
@@ -2968,12 +2905,14 @@
 						},
 						"has-unicode": {
 							"version": "2.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+							"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 							"optional": true
 						},
 						"iconv-lite": {
 							"version": "0.4.24",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+							"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 							"optional": true,
 							"requires": {
 								"safer-buffer": ">= 2.1.2 < 3"
@@ -2981,7 +2920,8 @@
 						},
 						"ignore-walk": {
 							"version": "3.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+							"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
 							"optional": true,
 							"requires": {
 								"minimatch": "^3.0.4"
@@ -2989,7 +2929,8 @@
 						},
 						"inflight": {
 							"version": "1.0.6",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+							"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 							"optional": true,
 							"requires": {
 								"once": "^1.3.0",
@@ -2998,17 +2939,20 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+							"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 							"optional": true
 						},
 						"ini": {
 							"version": "1.3.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+							"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 							"optional": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
@@ -3016,12 +2960,14 @@
 						},
 						"isarray": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 							"optional": true
 						},
 						"minimatch": {
 							"version": "3.0.4",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+							"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
@@ -3029,12 +2975,14 @@
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+							"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 							"optional": true
 						},
 						"minipass": {
 							"version": "2.3.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+							"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
 							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
@@ -3043,7 +2991,8 @@
 						},
 						"minizlib": {
 							"version": "1.2.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+							"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
 							"optional": true,
 							"requires": {
 								"minipass": "^2.2.1"
@@ -3051,7 +3000,8 @@
 						},
 						"mkdirp": {
 							"version": "0.5.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
@@ -3059,12 +3009,14 @@
 						},
 						"ms": {
 							"version": "2.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+							"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
 							"optional": true
 						},
 						"needle": {
 							"version": "2.3.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
+							"integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
 							"optional": true,
 							"requires": {
 								"debug": "^4.1.0",
@@ -3074,7 +3026,8 @@
 						},
 						"node-pre-gyp": {
 							"version": "0.12.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+							"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
 							"optional": true,
 							"requires": {
 								"detect-libc": "^1.0.2",
@@ -3091,7 +3044,8 @@
 						},
 						"nopt": {
 							"version": "4.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+							"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 							"optional": true,
 							"requires": {
 								"abbrev": "1",
@@ -3100,12 +3054,14 @@
 						},
 						"npm-bundled": {
 							"version": "1.0.6",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+							"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
 							"optional": true
 						},
 						"npm-packlist": {
 							"version": "1.4.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+							"integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
 							"optional": true,
 							"requires": {
 								"ignore-walk": "^3.0.1",
@@ -3114,7 +3070,8 @@
 						},
 						"npmlog": {
 							"version": "4.1.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+							"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 							"optional": true,
 							"requires": {
 								"are-we-there-yet": "~1.1.2",
@@ -3125,17 +3082,20 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+							"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 							"optional": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 							"optional": true
 						},
 						"once": {
 							"version": "1.4.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+							"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 							"optional": true,
 							"requires": {
 								"wrappy": "1"
@@ -3143,17 +3103,20 @@
 						},
 						"os-homedir": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+							"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 							"optional": true
 						},
 						"os-tmpdir": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+							"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 							"optional": true
 						},
 						"osenv": {
 							"version": "0.1.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+							"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 							"optional": true,
 							"requires": {
 								"os-homedir": "^1.0.0",
@@ -3162,17 +3125,20 @@
 						},
 						"path-is-absolute": {
 							"version": "1.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+							"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 							"optional": true
 						},
 						"process-nextick-args": {
 							"version": "2.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+							"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
 							"optional": true
 						},
 						"rc": {
 							"version": "1.2.8",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+							"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 							"optional": true,
 							"requires": {
 								"deep-extend": "^0.6.0",
@@ -3183,14 +3149,16 @@
 							"dependencies": {
 								"minimist": {
 									"version": "1.2.0",
-									"bundled": true,
+									"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+									"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 									"optional": true
 								}
 							}
 						},
 						"readable-stream": {
 							"version": "2.3.6",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"optional": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -3204,7 +3172,8 @@
 						},
 						"rimraf": {
 							"version": "2.6.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+							"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 							"optional": true,
 							"requires": {
 								"glob": "^7.1.3"
@@ -3212,37 +3181,44 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 							"optional": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+							"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 							"optional": true
 						},
 						"sax": {
 							"version": "1.2.4",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+							"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 							"optional": true
 						},
 						"semver": {
 							"version": "5.7.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+							"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 							"optional": true
 						},
 						"set-blocking": {
 							"version": "2.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+							"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 							"optional": true
 						},
 						"signal-exit": {
 							"version": "3.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+							"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 							"optional": true
 						},
 						"string-width": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
@@ -3252,7 +3228,8 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"optional": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -3260,7 +3237,8 @@
 						},
 						"strip-ansi": {
 							"version": "3.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
@@ -3268,12 +3246,14 @@
 						},
 						"strip-json-comments": {
 							"version": "2.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+							"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 							"optional": true
 						},
 						"tar": {
 							"version": "4.4.8",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+							"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
 							"optional": true,
 							"requires": {
 								"chownr": "^1.1.1",
@@ -3287,12 +3267,14 @@
 						},
 						"util-deprecate": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+							"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 							"optional": true
 						},
 						"wide-align": {
 							"version": "1.1.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+							"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 							"optional": true,
 							"requires": {
 								"string-width": "^1.0.2 || 2"
@@ -3300,12 +3282,14 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+							"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 							"optional": true
 						},
 						"yallist": {
 							"version": "3.0.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+							"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
 							"optional": true
 						}
 					}
@@ -3399,71 +3383,12 @@
 				}
 			}
 		},
-		"clean-stack": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-			"dev": true
-		},
 		"cli-cursor": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"requires": {
 				"restore-cursor": "^2.0.0"
-			}
-		},
-		"cli-truncate": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
-			"integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
-			"dev": true,
-			"requires": {
-				"slice-ansi": "0.0.4",
-				"string-width": "^1.0.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"slice-ansi": {
-					"version": "0.0.4",
-					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-					"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-					"dev": true
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				}
 			}
 		},
 		"cli-width": {
@@ -4162,12 +4087,6 @@
 				}
 			}
 		},
-		"date-fns": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-			"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
-			"dev": true
-		},
 		"date-now": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
@@ -4190,12 +4109,6 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
-		},
-		"dedent": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
-			"dev": true
 		},
 		"deep-equal": {
 			"version": "1.1.0",
@@ -4560,12 +4473,6 @@
 			"version": "1.3.262",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.262.tgz",
 			"integrity": "sha512-YFr53qZWr2pWkiTUorWEhAweujdf0ALiUp8VkNa0WGtbMVR+kZ8jNy3VTCemLsA4sT6+srCqehNn8TEAD0Ngrw=="
-		},
-		"elegant-spinner": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
-			"integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
-			"dev": true
 		},
 		"elliptic": {
 			"version": "6.5.1",
@@ -5589,15 +5496,6 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
-		"fastq": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
-			"integrity": "sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==",
-			"dev": true,
-			"requires": {
-				"reusify": "^1.0.0"
-			}
-		},
 		"faye-websocket": {
 			"version": "0.11.3",
 			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
@@ -5980,12 +5878,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
 			"integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg=="
-		},
-		"get-stdin": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
-			"integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
-			"dev": true
 		},
 		"get-stream": {
 			"version": "4.1.0",
@@ -6453,106 +6345,6 @@
 			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
 			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
 		},
-		"husky": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/husky/-/husky-3.0.5.tgz",
-			"integrity": "sha512-cKd09Jy9cDyNIvAdN2QQAP/oA21sle4FWXjIMDttailpLAYZuBE7WaPmhrkj+afS8Sj9isghAtFvWSQ0JiwOHg==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.4.2",
-				"cosmiconfig": "^5.2.1",
-				"execa": "^1.0.0",
-				"get-stdin": "^7.0.0",
-				"is-ci": "^2.0.0",
-				"opencollective-postinstall": "^2.0.2",
-				"pkg-dir": "^4.2.0",
-				"please-upgrade-node": "^3.2.0",
-				"read-pkg": "^5.1.1",
-				"run-node": "^1.0.0",
-				"slash": "^3.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
-				"parse-json": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-					"integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1",
-						"lines-and-columns": "^1.1.6"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				},
-				"pkg-dir": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-					"dev": true,
-					"requires": {
-						"find-up": "^4.0.0"
-					}
-				},
-				"read-pkg": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-					"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-					"dev": true,
-					"requires": {
-						"@types/normalize-package-data": "^2.4.0",
-						"normalize-package-data": "^2.5.0",
-						"parse-json": "^5.0.0",
-						"type-fest": "^0.6.0"
-					}
-				},
-				"slash": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-					"dev": true
-				},
-				"type-fest": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-					"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-					"dev": true
-				}
-			}
-		},
 		"iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -6640,12 +6432,6 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-		},
-		"indent-string": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-			"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-			"dev": true
 		},
 		"indexes-of": {
 			"version": "1.0.1",
@@ -6880,15 +6666,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-		},
-		"is-observable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
-			"integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
-			"dev": true,
-			"requires": {
-				"symbol-observable": "^1.1.0"
-			}
 		},
 		"is-path-cwd": {
 			"version": "1.0.0",
@@ -7314,22 +7091,26 @@
 					"dependencies": {
 						"abbrev": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+							"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 							"optional": true
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 							"optional": true
 						},
 						"aproba": {
 							"version": "1.2.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 							"optional": true
 						},
 						"are-we-there-yet": {
 							"version": "1.1.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+							"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 							"optional": true,
 							"requires": {
 								"delegates": "^1.0.0",
@@ -7338,12 +7119,14 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+							"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 							"optional": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+							"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
@@ -7352,32 +7135,38 @@
 						},
 						"chownr": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+							"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
 							"optional": true
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+							"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 							"optional": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+							"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 							"optional": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+							"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 							"optional": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+							"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 							"optional": true
 						},
 						"debug": {
 							"version": "4.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+							"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 							"optional": true,
 							"requires": {
 								"ms": "^2.1.1"
@@ -7385,22 +7174,26 @@
 						},
 						"deep-extend": {
 							"version": "0.6.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+							"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 							"optional": true
 						},
 						"delegates": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+							"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 							"optional": true
 						},
 						"detect-libc": {
 							"version": "1.0.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+							"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 							"optional": true
 						},
 						"fs-minipass": {
 							"version": "1.2.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+							"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
 							"optional": true,
 							"requires": {
 								"minipass": "^2.2.1"
@@ -7408,12 +7201,14 @@
 						},
 						"fs.realpath": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+							"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 							"optional": true
 						},
 						"gauge": {
 							"version": "2.7.4",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+							"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 							"optional": true,
 							"requires": {
 								"aproba": "^1.0.3",
@@ -7428,7 +7223,8 @@
 						},
 						"glob": {
 							"version": "7.1.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+							"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 							"optional": true,
 							"requires": {
 								"fs.realpath": "^1.0.0",
@@ -7441,12 +7237,14 @@
 						},
 						"has-unicode": {
 							"version": "2.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+							"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 							"optional": true
 						},
 						"iconv-lite": {
 							"version": "0.4.24",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+							"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 							"optional": true,
 							"requires": {
 								"safer-buffer": ">= 2.1.2 < 3"
@@ -7454,7 +7252,8 @@
 						},
 						"ignore-walk": {
 							"version": "3.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+							"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
 							"optional": true,
 							"requires": {
 								"minimatch": "^3.0.4"
@@ -7462,7 +7261,8 @@
 						},
 						"inflight": {
 							"version": "1.0.6",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+							"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 							"optional": true,
 							"requires": {
 								"once": "^1.3.0",
@@ -7471,17 +7271,20 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+							"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 							"optional": true
 						},
 						"ini": {
 							"version": "1.3.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+							"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 							"optional": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
@@ -7489,12 +7292,14 @@
 						},
 						"isarray": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 							"optional": true
 						},
 						"minimatch": {
 							"version": "3.0.4",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+							"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
@@ -7502,12 +7307,14 @@
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+							"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 							"optional": true
 						},
 						"minipass": {
 							"version": "2.3.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+							"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
 							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
@@ -7516,7 +7323,8 @@
 						},
 						"minizlib": {
 							"version": "1.2.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+							"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
 							"optional": true,
 							"requires": {
 								"minipass": "^2.2.1"
@@ -7524,7 +7332,8 @@
 						},
 						"mkdirp": {
 							"version": "0.5.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
@@ -7532,12 +7341,14 @@
 						},
 						"ms": {
 							"version": "2.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+							"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
 							"optional": true
 						},
 						"needle": {
 							"version": "2.3.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
+							"integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
 							"optional": true,
 							"requires": {
 								"debug": "^4.1.0",
@@ -7547,7 +7358,8 @@
 						},
 						"node-pre-gyp": {
 							"version": "0.12.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+							"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
 							"optional": true,
 							"requires": {
 								"detect-libc": "^1.0.2",
@@ -7564,7 +7376,8 @@
 						},
 						"nopt": {
 							"version": "4.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+							"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 							"optional": true,
 							"requires": {
 								"abbrev": "1",
@@ -7573,12 +7386,14 @@
 						},
 						"npm-bundled": {
 							"version": "1.0.6",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+							"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
 							"optional": true
 						},
 						"npm-packlist": {
 							"version": "1.4.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+							"integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
 							"optional": true,
 							"requires": {
 								"ignore-walk": "^3.0.1",
@@ -7587,7 +7402,8 @@
 						},
 						"npmlog": {
 							"version": "4.1.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+							"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 							"optional": true,
 							"requires": {
 								"are-we-there-yet": "~1.1.2",
@@ -7598,17 +7414,20 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+							"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 							"optional": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 							"optional": true
 						},
 						"once": {
 							"version": "1.4.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+							"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 							"optional": true,
 							"requires": {
 								"wrappy": "1"
@@ -7616,17 +7435,20 @@
 						},
 						"os-homedir": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+							"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 							"optional": true
 						},
 						"os-tmpdir": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+							"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 							"optional": true
 						},
 						"osenv": {
 							"version": "0.1.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+							"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 							"optional": true,
 							"requires": {
 								"os-homedir": "^1.0.0",
@@ -7635,17 +7457,20 @@
 						},
 						"path-is-absolute": {
 							"version": "1.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+							"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 							"optional": true
 						},
 						"process-nextick-args": {
 							"version": "2.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+							"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
 							"optional": true
 						},
 						"rc": {
 							"version": "1.2.8",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+							"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 							"optional": true,
 							"requires": {
 								"deep-extend": "^0.6.0",
@@ -7656,14 +7481,16 @@
 							"dependencies": {
 								"minimist": {
 									"version": "1.2.0",
-									"bundled": true,
+									"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+									"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 									"optional": true
 								}
 							}
 						},
 						"readable-stream": {
 							"version": "2.3.6",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"optional": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -7677,7 +7504,8 @@
 						},
 						"rimraf": {
 							"version": "2.6.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+							"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 							"optional": true,
 							"requires": {
 								"glob": "^7.1.3"
@@ -7685,37 +7513,44 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 							"optional": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+							"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 							"optional": true
 						},
 						"sax": {
 							"version": "1.2.4",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+							"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 							"optional": true
 						},
 						"semver": {
 							"version": "5.7.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+							"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 							"optional": true
 						},
 						"set-blocking": {
 							"version": "2.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+							"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 							"optional": true
 						},
 						"signal-exit": {
 							"version": "3.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+							"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 							"optional": true
 						},
 						"string-width": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
@@ -7725,7 +7560,8 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"optional": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -7733,7 +7569,8 @@
 						},
 						"strip-ansi": {
 							"version": "3.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
@@ -7741,12 +7578,14 @@
 						},
 						"strip-json-comments": {
 							"version": "2.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+							"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 							"optional": true
 						},
 						"tar": {
 							"version": "4.4.8",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+							"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
 							"optional": true,
 							"requires": {
 								"chownr": "^1.1.1",
@@ -7760,12 +7599,14 @@
 						},
 						"util-deprecate": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+							"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 							"optional": true
 						},
 						"wide-align": {
 							"version": "1.1.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+							"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 							"optional": true,
 							"requires": {
 								"string-width": "^1.0.2 || 2"
@@ -7773,12 +7614,14 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+							"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 							"optional": true
 						},
 						"yallist": {
 							"version": "3.0.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+							"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
 							"optional": true
 						}
 					}
@@ -8285,388 +8128,6 @@
 				"type-check": "~0.3.2"
 			}
 		},
-		"lines-and-columns": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
-			"dev": true
-		},
-		"lint-staged": {
-			"version": "9.2.5",
-			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-9.2.5.tgz",
-			"integrity": "sha512-d99gTBFMJ29159+9iRvaMEQstmNcPAbQbhHSYw6D/1FncvFdIj8lWHztaq3Uq+tbZPABHXQ/fyN7Rp1QwF8HIw==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.4.2",
-				"commander": "^2.20.0",
-				"cosmiconfig": "^5.2.1",
-				"debug": "^4.1.1",
-				"dedent": "^0.7.0",
-				"del": "^5.0.0",
-				"execa": "^2.0.3",
-				"listr": "^0.14.3",
-				"log-symbols": "^3.0.0",
-				"micromatch": "^4.0.2",
-				"normalize-path": "^3.0.0",
-				"please-upgrade-node": "^3.1.1",
-				"string-argv": "^0.3.0",
-				"stringify-object": "^3.3.0"
-			},
-			"dependencies": {
-				"@nodelib/fs.stat": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.2.tgz",
-					"integrity": "sha512-z8+wGWV2dgUhLqrtRYa03yDx4HWMvXKi1z8g3m2JyxAx8F7xk74asqPk5LAETjqDSGLFML/6CDl0+yFunSYicw==",
-					"dev": true
-				},
-				"array-union": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-					"dev": true
-				},
-				"braces": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-					"dev": true,
-					"requires": {
-						"fill-range": "^7.0.1"
-					}
-				},
-				"del": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/del/-/del-5.1.0.tgz",
-					"integrity": "sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==",
-					"dev": true,
-					"requires": {
-						"globby": "^10.0.1",
-						"graceful-fs": "^4.2.2",
-						"is-glob": "^4.0.1",
-						"is-path-cwd": "^2.2.0",
-						"is-path-inside": "^3.0.1",
-						"p-map": "^3.0.0",
-						"rimraf": "^3.0.0",
-						"slash": "^3.0.0"
-					}
-				},
-				"dir-glob": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-					"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-					"dev": true,
-					"requires": {
-						"path-type": "^4.0.0"
-					}
-				},
-				"execa": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-2.0.4.tgz",
-					"integrity": "sha512-VcQfhuGD51vQUQtKIq2fjGDLDbL6N1DTQVpYzxZ7LPIXw3HqTuIz6uxRmpV1qf8i31LHf2kjiaGI+GdHwRgbnQ==",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^6.0.5",
-						"get-stream": "^5.0.0",
-						"is-stream": "^2.0.0",
-						"merge-stream": "^2.0.0",
-						"npm-run-path": "^3.0.0",
-						"onetime": "^5.1.0",
-						"p-finally": "^2.0.0",
-						"signal-exit": "^3.0.2",
-						"strip-final-newline": "^2.0.0"
-					}
-				},
-				"fast-glob": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.0.4.tgz",
-					"integrity": "sha512-wkIbV6qg37xTJwqSsdnIphL1e+LaGz4AIQqr00mIubMaEhv1/HEmJ0uuCGZRNRUkZZmOB5mJKO0ZUTVq+SxMQg==",
-					"dev": true,
-					"requires": {
-						"@nodelib/fs.stat": "^2.0.1",
-						"@nodelib/fs.walk": "^1.2.1",
-						"glob-parent": "^5.0.0",
-						"is-glob": "^4.0.1",
-						"merge2": "^1.2.3",
-						"micromatch": "^4.0.2"
-					}
-				},
-				"fill-range": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-					"dev": true,
-					"requires": {
-						"to-regex-range": "^5.0.1"
-					}
-				},
-				"get-stream": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
-				"globby": {
-					"version": "10.0.1",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
-					"integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
-					"dev": true,
-					"requires": {
-						"@types/glob": "^7.1.1",
-						"array-union": "^2.1.0",
-						"dir-glob": "^3.0.1",
-						"fast-glob": "^3.0.3",
-						"glob": "^7.1.3",
-						"ignore": "^5.1.1",
-						"merge2": "^1.2.3",
-						"slash": "^3.0.0"
-					}
-				},
-				"ignore": {
-					"version": "5.1.4",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-					"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
-					"dev": true
-				},
-				"is-number": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-					"dev": true
-				},
-				"is-path-cwd": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-					"integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
-					"dev": true
-				},
-				"is-path-inside": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.1.tgz",
-					"integrity": "sha512-CKstxrctq1kUesU6WhtZDbYKzzYBuRH0UYInAVrkc/EYdB9ltbfE0gOoayG9nhohG6447sOOVGhHqsdmBvkbNg==",
-					"dev": true
-				},
-				"is-stream": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-					"dev": true
-				},
-				"micromatch": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-					"dev": true,
-					"requires": {
-						"braces": "^3.0.1",
-						"picomatch": "^2.0.5"
-					}
-				},
-				"mimic-fn": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-					"dev": true
-				},
-				"normalize-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-					"dev": true
-				},
-				"npm-run-path": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
-					"integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
-					"dev": true,
-					"requires": {
-						"path-key": "^3.0.0"
-					}
-				},
-				"onetime": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-					"integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-					"dev": true,
-					"requires": {
-						"mimic-fn": "^2.1.0"
-					}
-				},
-				"p-finally": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-					"integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
-					"dev": true
-				},
-				"p-map": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-					"integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
-					"dev": true,
-					"requires": {
-						"aggregate-error": "^3.0.0"
-					}
-				},
-				"path-key": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
-					"integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
-					"dev": true
-				},
-				"path-type": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-					"dev": true
-				},
-				"rimraf": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
-					"integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"slash": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-					"dev": true
-				},
-				"to-regex-range": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-					"dev": true,
-					"requires": {
-						"is-number": "^7.0.0"
-					}
-				}
-			}
-		},
-		"listr": {
-			"version": "0.14.3",
-			"resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
-			"integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
-			"dev": true,
-			"requires": {
-				"@samverschueren/stream-to-observable": "^0.3.0",
-				"is-observable": "^1.1.0",
-				"is-promise": "^2.1.0",
-				"is-stream": "^1.1.0",
-				"listr-silent-renderer": "^1.1.1",
-				"listr-update-renderer": "^0.5.0",
-				"listr-verbose-renderer": "^0.5.0",
-				"p-map": "^2.0.0",
-				"rxjs": "^6.3.3"
-			},
-			"dependencies": {
-				"p-map": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-					"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-					"dev": true
-				}
-			}
-		},
-		"listr-silent-renderer": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
-			"integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
-			"dev": true
-		},
-		"listr-update-renderer": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
-			"integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
-			"dev": true,
-			"requires": {
-				"chalk": "^1.1.3",
-				"cli-truncate": "^0.2.1",
-				"elegant-spinner": "^1.0.1",
-				"figures": "^1.7.0",
-				"indent-string": "^3.0.0",
-				"log-symbols": "^1.0.2",
-				"log-update": "^2.3.0",
-				"strip-ansi": "^3.0.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"figures": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-					"dev": true,
-					"requires": {
-						"escape-string-regexp": "^1.0.5",
-						"object-assign": "^4.1.0"
-					}
-				},
-				"log-symbols": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-					"dev": true,
-					"requires": {
-						"chalk": "^1.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
-				}
-			}
-		},
-		"listr-verbose-renderer": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
-			"integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.4.1",
-				"cli-cursor": "^2.1.0",
-				"date-fns": "^1.27.2",
-				"figures": "^2.0.0"
-			}
-		},
 		"load-json-file": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -8819,47 +8280,6 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
 			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
-		},
-		"log-symbols": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
-			"integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.4.2"
-			}
-		},
-		"log-update": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
-			"integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
-			"dev": true,
-			"requires": {
-				"ansi-escapes": "^3.0.0",
-				"cli-cursor": "^2.0.0",
-				"wrap-ansi": "^3.0.1"
-			},
-			"dependencies": {
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
-					"integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
-					"dev": true,
-					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0"
-					}
-				}
-			}
 		},
 		"loglevel": {
 			"version": "1.6.4",
@@ -9696,12 +9116,6 @@
 				"is-wsl": "^1.1.0"
 			}
 		},
-		"opencollective-postinstall": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
-			"integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
-			"dev": true
-		},
 		"opn": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
@@ -9999,12 +9413,6 @@
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
-		"picomatch": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
-			"integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==",
-			"dev": true
-		},
 		"pify": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -10085,15 +9493,6 @@
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
 					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
 				}
-			}
-		},
-		"please-upgrade-node": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
-			"integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
-			"dev": true,
-			"requires": {
-				"semver-compare": "^1.0.0"
 			}
 		},
 		"pn": {
@@ -11825,12 +11224,6 @@
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
 			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
 		},
-		"reusify": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-			"dev": true
-		},
 		"rework": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/rework/-/rework-1.0.1.tgz",
@@ -11900,18 +11293,6 @@
 			"requires": {
 				"is-promise": "^2.1.0"
 			}
-		},
-		"run-node": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/run-node/-/run-node-1.0.0.tgz",
-			"integrity": "sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==",
-			"dev": true
-		},
-		"run-parallel": {
-			"version": "1.1.9",
-			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
-			"dev": true
 		},
 		"run-queue": {
 			"version": "1.0.3",
@@ -12059,12 +11440,6 @@
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-		},
-		"semver-compare": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-			"integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
-			"dev": true
 		},
 		"send": {
 			"version": "0.17.1",
@@ -12728,12 +12103,6 @@
 			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
 			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
 		},
-		"string-argv": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
-			"integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
-			"dev": true
-		},
 		"string-length": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -12859,12 +12228,6 @@
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 		},
-		"strip-final-newline": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-			"dev": true
-		},
 		"strip-json-comments": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
@@ -12944,12 +12307,6 @@
 				"unquote": "~1.1.1",
 				"util.promisify": "~1.0.0"
 			}
-		},
-		"symbol-observable": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-			"dev": true
 		},
 		"symbol-tree": {
 			"version": "3.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-	"name": "ungroup",
-	"version": "0.1.0",
+	"name": "@sparksuite/salary-calculator",
+	"version": "0.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,18 @@
 		]
 	},
 	"devDependencies": {
+		"@typescript-eslint/eslint-plugin": "^2.3.0",
+		"@typescript-eslint/parser": "^2.3.0",
+		"babel-eslint": "^10.0.3",
+		"eslint": "^6.4.0",
+		"eslint-config-prettier": "^6.3.0",
+		"eslint-config-react-app": "^5.0.2",
+		"eslint-plugin-flowtype": "^3.13.0",
+		"eslint-plugin-import": "^2.18.2",
+		"eslint-plugin-jsx-a11y": "^6.2.3",
+		"eslint-plugin-prettier": "^3.1.1",
+		"eslint-plugin-react": "^7.14.3",
+		"eslint-plugin-react-hooks": "^1.7.0",
 		"husky": "^3.0.5",
 		"lint-staged": "^9.2.5",
 		"prettier": "1.18.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-	"name": "ungroup",
-	"version": "0.1.0",
+	"name": "@sparksuite/salary-calculator",
+	"version": "0.0.0",
 	"private": true,
 	"dependencies": {
 		"@types/jest": "24.0.18",

--- a/package.json
+++ b/package.json
@@ -49,19 +49,6 @@
 		"eslint-plugin-prettier": "^3.1.1",
 		"eslint-plugin-react": "^7.14.3",
 		"eslint-plugin-react-hooks": "^1.7.0",
-		"husky": "^3.0.5",
-		"lint-staged": "^9.2.5",
 		"prettier": "1.18.2"
-	},
-	"husky": {
-		"hooks": {
-			"pre-commit": "lint-staged"
-		}
-	},
-	"lint-staged": {
-		"*.{js,jsx,ts,tsx,css,json,md}": [
-			"prettier --write",
-			"git add"
-		]
 	}
 }


### PR DESCRIPTION
This PR integrates ESLint and ties it together with Prettier. I've decided to remove the pre-commit hook as well, since it slows down the commit process and makes changes that the engineer cannot easily review. This also incorporates code linting into Travis CI and all-around improves the integration with Travis CI.