### PR TITLE
Specify Travis CI build stage order explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ cache:
 branches:
   only:
     - master
+stages:
+  - test
+  - deploy
 jobs:
   include:
     - stage: test


### PR DESCRIPTION
Adds the `stages` key to the `.travis.yml` file so that build stages are explicitly ordered. It's more clear and it may avoid future issues.