### PR TITLE
Fix missing build step before deploying

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ jobs:
       if: type = push
       name: Deploy to GitHub Pages
       node_js: lts/*
+      script:
+        - npm run build
       deploy:
         provider: pages
         local_dir: build


### PR DESCRIPTION
There was no `npm run build` command before deploying.