### PR TITLE
Use a custom subdomain for GitHub Pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,4 @@ jobs:
         local_dir: build
         skip_cleanup: true
         github_token: $GITHUB_TOKEN
+        fqdn: salaries.sparksuite.com


### PR DESCRIPTION
Will now use `salaries.sparksuite.com` for the GitHub Pages deployment, through Travis CI.