### PR TITLE
Fix issues with ESLint and Prettier not running correctly

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,13 @@
 {
-	"extends": [
-		"plugin:prettier/recommended",
-		"react-app",
-		"plugin:jsx-a11y/recommended"
-	],
-	"plugins": ["jsx-a11y"]
+	"extends": ["react-app", "plugin:jsx-a11y/recommended", "prettier"],
+	"plugins": ["jsx-a11y"],
+	"rules": {
+		"no-unused-vars": [
+			"error",
+			{
+				"vars": "all",
+				"args": "after-used"
+			}
+		]
+	}
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,6 @@
 {
-    "jsxSingleQuote": true,
-    "singleQuote": true,
-    "trailingComma": "es5",
-    "useTabs": true
+	"jsxSingleQuote": true,
+	"singleQuote": true,
+	"trailingComma": "es5",
+	"useTabs": true
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
       name: Lint code
       node_js: lts/*
       script:
-        - npx eslint .
+        - npm run lint
     - stage: test
       name: Verify build
       node_js: lts/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -5059,15 +5059,6 @@
 				"jsx-ast-utils": "^2.2.1"
 			}
 		},
-		"eslint-plugin-prettier": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.1.tgz",
-			"integrity": "sha512-A+TZuHZ0KU0cnn56/9mfR7/KjUJ9QNVXUhwvRFSR7PGPe0zQR6PTkmyqg1AtUUEOzTqeRsUwyKFh0oVZKVCrtA==",
-			"dev": true,
-			"requires": {
-				"prettier-linter-helpers": "^1.0.0"
-			}
-		},
 		"eslint-plugin-react": {
 			"version": "7.14.3",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
@@ -5445,12 +5436,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
 			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-		},
-		"fast-diff": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
-			"dev": true
 		},
 		"fast-glob": {
 			"version": "2.2.7",
@@ -10382,15 +10367,6 @@
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
 			"integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
 			"dev": true
-		},
-		"prettier-linter-helpers": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-			"integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-			"dev": true,
-			"requires": {
-				"fast-diff": "^1.1.2"
-			}
 		},
 		"pretty-bytes": {
 			"version": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -18,10 +18,9 @@
 		"start": "react-scripts start",
 		"build": "react-scripts build",
 		"test": "react-scripts test",
-		"eject": "react-scripts eject"
-	},
-	"eslintConfig": {
-		"extends": "react-app"
+		"eject": "react-scripts eject",
+		"lint": "eslint . --ext .js,.jsx,.ts,.tsx && prettier --check '**/*.{js,jsx,ts,tsx,json}'",
+		"format": "eslint --fix . --ext .js,.jsx,.ts,.tsx && prettier --write '**/*.{js,jsx,ts,tsx,json}'"
 	},
 	"browserslist": {
 		"production": [
@@ -45,7 +44,6 @@
 		"eslint-plugin-flowtype": "^3.13.0",
 		"eslint-plugin-import": "^2.18.2",
 		"eslint-plugin-jsx-a11y": "^6.2.3",
-		"eslint-plugin-prettier": "^3.1.1",
 		"eslint-plugin-react": "^7.14.3",
 		"eslint-plugin-react-hooks": "^1.7.0",
 		"prettier": "1.18.2"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,25 +1,25 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
-  "icons": [
-    {
-      "src": "favicon.ico",
-      "sizes": "64x64 32x32 24x24 16x16",
-      "type": "image/x-icon"
-    },
-    {
-      "src": "logo192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
-    }
-  ],
-  "start_url": ".",
-  "display": "standalone",
-  "theme_color": "#000000",
-  "background_color": "#ffffff"
+	"short_name": "React App",
+	"name": "Create React App Sample",
+	"icons": [
+		{
+			"src": "favicon.ico",
+			"sizes": "64x64 32x32 24x24 16x16",
+			"type": "image/x-icon"
+		},
+		{
+			"src": "logo192.png",
+			"type": "image/png",
+			"sizes": "192x192"
+		},
+		{
+			"src": "logo512.png",
+			"type": "image/png",
+			"sizes": "512x512"
+		}
+	],
+	"start_url": ".",
+	"display": "standalone",
+	"theme_color": "#000000",
+	"background_color": "#ffffff"
 }

--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -11,133 +11,133 @@
 // opt-in, read https://bit.ly/CRA-PWA
 
 const isLocalhost = Boolean(
-  window.location.hostname === 'localhost' ||
-    // [::1] is the IPv6 localhost address.
-    window.location.hostname === '[::1]' ||
-    // 127.0.0.1/8 is considered localhost for IPv4.
-    window.location.hostname.match(
-      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
-    )
+	window.location.hostname === 'localhost' ||
+		// [::1] is the IPv6 localhost address.
+		window.location.hostname === '[::1]' ||
+		// 127.0.0.1/8 is considered localhost for IPv4.
+		window.location.hostname.match(
+			/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
+		)
 );
 
 type Config = {
-  onSuccess?: (registration: ServiceWorkerRegistration) => void;
-  onUpdate?: (registration: ServiceWorkerRegistration) => void;
+	onSuccess?: (registration: ServiceWorkerRegistration) => void;
+	onUpdate?: (registration: ServiceWorkerRegistration) => void;
 };
 
 export function register(config?: Config) {
-  if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
-    // The URL constructor is available in all browsers that support SW.
-    const publicUrl = new URL(
-      (process as { env: { [key: string]: string } }).env.PUBLIC_URL,
-      window.location.href
-    );
-    if (publicUrl.origin !== window.location.origin) {
-      // Our service worker won't work if PUBLIC_URL is on a different origin
-      // from what our page is served on. This might happen if a CDN is used to
-      // serve assets; see https://github.com/facebook/create-react-app/issues/2374
-      return;
-    }
+	if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+		// The URL constructor is available in all browsers that support SW.
+		const publicUrl = new URL(
+			(process as { env: { [key: string]: string } }).env.PUBLIC_URL,
+			window.location.href
+		);
+		if (publicUrl.origin !== window.location.origin) {
+			// Our service worker won't work if PUBLIC_URL is on a different origin
+			// from what our page is served on. This might happen if a CDN is used to
+			// serve assets; see https://github.com/facebook/create-react-app/issues/2374
+			return;
+		}
 
-    window.addEventListener('load', () => {
-      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
+		window.addEventListener('load', () => {
+			const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
 
-      if (isLocalhost) {
-        // This is running on localhost. Let's check if a service worker still exists or not.
-        checkValidServiceWorker(swUrl, config);
+			if (isLocalhost) {
+				// This is running on localhost. Let's check if a service worker still exists or not.
+				checkValidServiceWorker(swUrl, config);
 
-        // Add some additional logging to localhost, pointing developers to the
-        // service worker/PWA documentation.
-        navigator.serviceWorker.ready.then(() => {
-          console.log(
-            'This web app is being served cache-first by a service ' +
-              'worker. To learn more, visit https://bit.ly/CRA-PWA'
-          );
-        });
-      } else {
-        // Is not localhost. Just register service worker
-        registerValidSW(swUrl, config);
-      }
-    });
-  }
+				// Add some additional logging to localhost, pointing developers to the
+				// service worker/PWA documentation.
+				navigator.serviceWorker.ready.then(() => {
+					console.log(
+						'This web app is being served cache-first by a service ' +
+							'worker. To learn more, visit https://bit.ly/CRA-PWA'
+					);
+				});
+			} else {
+				// Is not localhost. Just register service worker
+				registerValidSW(swUrl, config);
+			}
+		});
+	}
 }
 
 function registerValidSW(swUrl: string, config?: Config) {
-  navigator.serviceWorker
-    .register(swUrl)
-    .then(registration => {
-      registration.onupdatefound = () => {
-        const installingWorker = registration.installing;
-        if (installingWorker == null) {
-          return;
-        }
-        installingWorker.onstatechange = () => {
-          if (installingWorker.state === 'installed') {
-            if (navigator.serviceWorker.controller) {
-              // At this point, the updated precached content has been fetched,
-              // but the previous service worker will still serve the older
-              // content until all client tabs are closed.
-              console.log(
-                'New content is available and will be used when all ' +
-                  'tabs for this page are closed. See https://bit.ly/CRA-PWA.'
-              );
+	navigator.serviceWorker
+		.register(swUrl)
+		.then(registration => {
+			registration.onupdatefound = () => {
+				const installingWorker = registration.installing;
+				if (installingWorker == null) {
+					return;
+				}
+				installingWorker.onstatechange = () => {
+					if (installingWorker.state === 'installed') {
+						if (navigator.serviceWorker.controller) {
+							// At this point, the updated precached content has been fetched,
+							// but the previous service worker will still serve the older
+							// content until all client tabs are closed.
+							console.log(
+								'New content is available and will be used when all ' +
+									'tabs for this page are closed. See https://bit.ly/CRA-PWA.'
+							);
 
-              // Execute callback
-              if (config && config.onUpdate) {
-                config.onUpdate(registration);
-              }
-            } else {
-              // At this point, everything has been precached.
-              // It's the perfect time to display a
-              // "Content is cached for offline use." message.
-              console.log('Content is cached for offline use.');
+							// Execute callback
+							if (config && config.onUpdate) {
+								config.onUpdate(registration);
+							}
+						} else {
+							// At this point, everything has been precached.
+							// It's the perfect time to display a
+							// "Content is cached for offline use." message.
+							console.log('Content is cached for offline use.');
 
-              // Execute callback
-              if (config && config.onSuccess) {
-                config.onSuccess(registration);
-              }
-            }
-          }
-        };
-      };
-    })
-    .catch(error => {
-      console.error('Error during service worker registration:', error);
-    });
+							// Execute callback
+							if (config && config.onSuccess) {
+								config.onSuccess(registration);
+							}
+						}
+					}
+				};
+			};
+		})
+		.catch(error => {
+			console.error('Error during service worker registration:', error);
+		});
 }
 
 function checkValidServiceWorker(swUrl: string, config?: Config) {
-  // Check if the service worker can be found. If it can't reload the page.
-  fetch(swUrl)
-    .then(response => {
-      // Ensure service worker exists, and that we really are getting a JS file.
-      const contentType = response.headers.get('content-type');
-      if (
-        response.status === 404 ||
-        (contentType != null && contentType.indexOf('javascript') === -1)
-      ) {
-        // No service worker found. Probably a different app. Reload the page.
-        navigator.serviceWorker.ready.then(registration => {
-          registration.unregister().then(() => {
-            window.location.reload();
-          });
-        });
-      } else {
-        // Service worker found. Proceed as normal.
-        registerValidSW(swUrl, config);
-      }
-    })
-    .catch(() => {
-      console.log(
-        'No internet connection found. App is running in offline mode.'
-      );
-    });
+	// Check if the service worker can be found. If it can't reload the page.
+	fetch(swUrl)
+		.then(response => {
+			// Ensure service worker exists, and that we really are getting a JS file.
+			const contentType = response.headers.get('content-type');
+			if (
+				response.status === 404 ||
+				(contentType != null && contentType.indexOf('javascript') === -1)
+			) {
+				// No service worker found. Probably a different app. Reload the page.
+				navigator.serviceWorker.ready.then(registration => {
+					registration.unregister().then(() => {
+						window.location.reload();
+					});
+				});
+			} else {
+				// Service worker found. Proceed as normal.
+				registerValidSW(swUrl, config);
+			}
+		})
+		.catch(() => {
+			console.log(
+				'No internet connection found. App is running in offline mode.'
+			);
+		});
 }
 
 export function unregister() {
-  if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.ready.then(registration => {
-      registration.unregister();
-    });
-  }
+	if ('serviceWorker' in navigator) {
+		navigator.serviceWorker.ready.then(registration => {
+			registration.unregister();
+		});
+	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,25 +1,19 @@
 {
-  "compilerOptions": {
-    "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react"
-  },
-  "include": [
-    "src"
-  ]
+	"compilerOptions": {
+		"target": "es5",
+		"lib": ["dom", "dom.iterable", "esnext"],
+		"allowJs": true,
+		"skipLibCheck": true,
+		"esModuleInterop": true,
+		"allowSyntheticDefaultImports": true,
+		"strict": true,
+		"forceConsistentCasingInFileNames": true,
+		"module": "esnext",
+		"moduleResolution": "node",
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true,
+		"jsx": "react"
+	},
+	"include": ["src"]
 }


### PR DESCRIPTION
Now there are two dedicated commands that run linting/formatting in our desired way:

- `npm run lint`
- `npm run format`

As we build out this web app, it may become apparent that we need to add additional rules to the ESLint config.