### PR TITLE
Prevent unavailable tenures

### DIFF
--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -169,15 +169,6 @@ exports[`Storyshots Choices Normal 1`] = `
         <option>
           one to two years
         </option>
-        <option>
-          two to three years
-        </option>
-        <option>
-          three to four years
-        </option>
-        <option>
-          more than four years
-        </option>
       </select>
     </div>
   </div>

--- a/src/components/choices.tsx
+++ b/src/components/choices.tsx
@@ -47,18 +47,43 @@ const Choices: React.FC = () => {
 		}
 	}
 
-	// Get the currently-selected position's field descriptor
+	// Get the currently-selected position's field descriptor and annual raises
 	const selectedPosition = useSelector((state: AppState) => state.position);
 	let fieldDescriptor = '';
+	let annualRaises = [0];
 
 	for (const field of data.fields) {
 		for (const role of field.roles) {
 			for (const level of role.levels) {
 				if (level.title === selectedPosition) {
 					fieldDescriptor = field.descriptor;
+					annualRaises = level.annualRaises;
 				}
 			}
 		}
+	}
+	
+	// Determine available tenures
+	let possibleExtraTenures = [
+		'one to two years',
+		'two to three years',
+		'three to four years',
+		'more than four years',
+	];
+	
+	let tenures = [
+		'less than one year',
+	];
+	
+	for (let i = 0; i < annualRaises.length; i++) {
+		tenures.push(possibleExtraTenures[i]);
+	}
+	
+	// Reset tenure if currently-selected one is unavailable
+	const selectedTenure = useSelector((state: AppState) => state.tenure);
+	
+	if (!tenures.includes(selectedTenure)) {
+		dispatch(actions.setTenure(tenures[0]));
 	}
 
 	// Return JSX
@@ -79,13 +104,7 @@ const Choices: React.FC = () => {
 				Sparksuite family for
 			</Text>
 			<Choice
-				choices={[
-					'less than one year',
-					'one to two years',
-					'two to three years',
-					'three to four years',
-					'more than four years',
-				]}
+				choices={tenures}
 				onChange={(value: string) => dispatch(actions.setTenure(value))}
 			/>
 		</Container>

--- a/src/components/choices.tsx
+++ b/src/components/choices.tsx
@@ -62,7 +62,7 @@ const Choices: React.FC = () => {
 			}
 		}
 	}
-	
+
 	// Determine available tenures
 	let possibleExtraTenures = [
 		'one to two years',
@@ -70,18 +70,16 @@ const Choices: React.FC = () => {
 		'three to four years',
 		'more than four years',
 	];
-	
-	let tenures = [
-		'less than one year',
-	];
-	
+
+	let tenures = ['less than one year'];
+
 	for (let i = 0; i < annualRaises.length; i++) {
 		tenures.push(possibleExtraTenures[i]);
 	}
-	
+
 	// Reset tenure if currently-selected one is unavailable
 	const selectedTenure = useSelector((state: AppState) => state.tenure);
-	
+
 	if (!tenures.includes(selectedTenure)) {
 		dispatch(actions.setTenure(tenures[0]));
 	}

--- a/src/components/compensation.tsx
+++ b/src/components/compensation.tsx
@@ -73,16 +73,16 @@ const Compensation: React.FC = () => {
 	// Determine base salary
 	let baseSalary = levelDetails.startingSalary;
 
-	const tenure = useSelector((state: AppState) => state.tenure);
+	const selectedTenure = useSelector((state: AppState) => state.tenure);
 	let loopCount = 0;
 
-	if (tenure === 'one to two years') {
+	if (selectedTenure === 'one to two years') {
 		loopCount = 1;
-	} else if (tenure === 'two to three years') {
+	} else if (selectedTenure === 'two to three years') {
 		loopCount = 2;
-	} else if (tenure === 'three to four years') {
+	} else if (selectedTenure === 'three to four years') {
 		loopCount = 3;
-	} else if (tenure === 'more than four years') {
+	} else if (selectedTenure === 'more than four years') {
 		loopCount = 4;
 	}
 


### PR DESCRIPTION
Certain tenures are unavailable since they don't make sense for particular levels. For instance, one cannot be "just beginning" their professional career as a level I engineer, while also having worked as an engineer for more than four years with us.