### PR TITLE
Fix a spacing issue with figure elements

### DIFF
--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -193,16 +193,15 @@ exports[`Storyshots Compensation Normal 1`] = `
     className="container__Container-sc-8aaowj-0 kvuGWV"
   >
     <figure
+      className="figure__Container-sc-1fhptnd-0 gDCPtV"
       style={
         Object {
           "fontSize": "1rem",
-          "position": "relative",
-          "textAlign": "center",
         }
       }
     >
       <div
-        className="figure__Amount-sc-1fhptnd-1 kgQDra"
+        className="figure__Amount-sc-1fhptnd-2 iVgVzS"
         style={
           Object {
             "color": undefined,
@@ -212,7 +211,7 @@ exports[`Storyshots Compensation Normal 1`] = `
         $85,000
       </div>
       <figcaption
-        className="figure__Subtitle-sc-1fhptnd-2 ftqwVr"
+        className="figure__Subtitle-sc-1fhptnd-3 bGhMwz"
       >
         BASE SALARY
       </figcaption>
@@ -231,16 +230,15 @@ exports[`Storyshots Compensation Normal 1`] = `
     >
       <div>
         <figure
+          className="figure__Container-sc-1fhptnd-0 gDCPtV"
           style={
             Object {
               "fontSize": "0.8rem",
-              "position": "relative",
-              "textAlign": "center",
             }
           }
         >
           <div
-            className="figure__Amount-sc-1fhptnd-1 kgQDra"
+            className="figure__Amount-sc-1fhptnd-2 iVgVzS"
             style={
               Object {
                 "color": "#67b1d6",
@@ -250,7 +248,7 @@ exports[`Storyshots Compensation Normal 1`] = `
             $4,800
           </div>
           <figcaption
-            className="figure__Subtitle-sc-1fhptnd-2 ftqwVr"
+            className="figure__Subtitle-sc-1fhptnd-3 bGhMwz"
           >
             TAX-FREE HRA FUNDS
             <a
@@ -271,21 +269,20 @@ exports[`Storyshots Compensation Normal 1`] = `
       </div>
       <div>
         <figure
+          className="figure__Container-sc-1fhptnd-0 gDCPtV"
           style={
             Object {
               "fontSize": "0.8rem",
-              "position": "relative",
-              "textAlign": "center",
             }
           }
         >
           <div
-            className="figure__UpTo-sc-1fhptnd-0 bbqMgx"
+            className="figure__UpTo-sc-1fhptnd-1 jFdPgY"
           >
             UP TO
           </div>
           <div
-            className="figure__Amount-sc-1fhptnd-1 kgQDra"
+            className="figure__Amount-sc-1fhptnd-2 iVgVzS"
             style={
               Object {
                 "color": "#67b1d6",
@@ -295,7 +292,7 @@ exports[`Storyshots Compensation Normal 1`] = `
             $3,400
           </div>
           <figcaption
-            className="figure__Subtitle-sc-1fhptnd-2 ftqwVr"
+            className="figure__Subtitle-sc-1fhptnd-3 bGhMwz"
           >
             MATCHING 401(k) CONTRIBUTIONS
             <a
@@ -408,16 +405,15 @@ exports[`Storyshots Figure Basic 1`] = `
   }
 >
   <figure
+    className="figure__Container-sc-1fhptnd-0 gDCPtV"
     style={
       Object {
         "fontSize": "1rem",
-        "position": "relative",
-        "textAlign": "center",
       }
     }
   >
     <div
-      className="figure__Amount-sc-1fhptnd-1 kgQDra"
+      className="figure__Amount-sc-1fhptnd-2 iVgVzS"
       style={
         Object {
           "color": undefined,
@@ -427,7 +423,7 @@ exports[`Storyshots Figure Basic 1`] = `
       $123,456
     </div>
     <figcaption
-      className="figure__Subtitle-sc-1fhptnd-2 ftqwVr"
+      className="figure__Subtitle-sc-1fhptnd-3 bGhMwz"
     >
       EXAMPLE SUBTITLE
     </figcaption>
@@ -445,16 +441,15 @@ exports[`Storyshots Figure Custom Color 1`] = `
   }
 >
   <figure
+    className="figure__Container-sc-1fhptnd-0 gDCPtV"
     style={
       Object {
         "fontSize": "1rem",
-        "position": "relative",
-        "textAlign": "center",
       }
     }
   >
     <div
-      className="figure__Amount-sc-1fhptnd-1 kgQDra"
+      className="figure__Amount-sc-1fhptnd-2 iVgVzS"
       style={
         Object {
           "color": "#f00",
@@ -464,7 +459,7 @@ exports[`Storyshots Figure Custom Color 1`] = `
       $123,456
     </div>
     <figcaption
-      className="figure__Subtitle-sc-1fhptnd-2 ftqwVr"
+      className="figure__Subtitle-sc-1fhptnd-3 bGhMwz"
     >
       EXAMPLE SUBTITLE
     </figcaption>
@@ -482,16 +477,15 @@ exports[`Storyshots Figure Info Icon 1`] = `
   }
 >
   <figure
+    className="figure__Container-sc-1fhptnd-0 gDCPtV"
     style={
       Object {
         "fontSize": "1rem",
-        "position": "relative",
-        "textAlign": "center",
       }
     }
   >
     <div
-      className="figure__Amount-sc-1fhptnd-1 kgQDra"
+      className="figure__Amount-sc-1fhptnd-2 iVgVzS"
       style={
         Object {
           "color": undefined,
@@ -501,7 +495,7 @@ exports[`Storyshots Figure Info Icon 1`] = `
       $123,456
     </div>
     <figcaption
-      className="figure__Subtitle-sc-1fhptnd-2 ftqwVr"
+      className="figure__Subtitle-sc-1fhptnd-3 bGhMwz"
     >
       EXAMPLE SUBTITLE
       <a
@@ -529,16 +523,15 @@ exports[`Storyshots Figure Smaller 1`] = `
   }
 >
   <figure
+    className="figure__Container-sc-1fhptnd-0 gDCPtV"
     style={
       Object {
         "fontSize": "0.8rem",
-        "position": "relative",
-        "textAlign": "center",
       }
     }
   >
     <div
-      className="figure__Amount-sc-1fhptnd-1 kgQDra"
+      className="figure__Amount-sc-1fhptnd-2 iVgVzS"
       style={
         Object {
           "color": undefined,
@@ -548,7 +541,7 @@ exports[`Storyshots Figure Smaller 1`] = `
       $123,456
     </div>
     <figcaption
-      className="figure__Subtitle-sc-1fhptnd-2 ftqwVr"
+      className="figure__Subtitle-sc-1fhptnd-3 bGhMwz"
     >
       EXAMPLE SUBTITLE
     </figcaption>
@@ -566,21 +559,20 @@ exports[`Storyshots Figure Up To 1`] = `
   }
 >
   <figure
+    className="figure__Container-sc-1fhptnd-0 gDCPtV"
     style={
       Object {
         "fontSize": "1rem",
-        "position": "relative",
-        "textAlign": "center",
       }
     }
   >
     <div
-      className="figure__UpTo-sc-1fhptnd-0 bbqMgx"
+      className="figure__UpTo-sc-1fhptnd-1 jFdPgY"
     >
       UP TO
     </div>
     <div
-      className="figure__Amount-sc-1fhptnd-1 kgQDra"
+      className="figure__Amount-sc-1fhptnd-2 iVgVzS"
       style={
         Object {
           "color": undefined,
@@ -590,7 +582,7 @@ exports[`Storyshots Figure Up To 1`] = `
       $123,456
     </div>
     <figcaption
-      className="figure__Subtitle-sc-1fhptnd-2 ftqwVr"
+      className="figure__Subtitle-sc-1fhptnd-3 bGhMwz"
     >
       EXAMPLE SUBTITLE
     </figcaption>

--- a/src/components/figure.tsx
+++ b/src/components/figure.tsx
@@ -3,6 +3,13 @@ import React from 'react';
 import styled from 'styled-components/macro';
 
 // Styled elements
+const Container = styled.figure`
+	margin: 0;
+	padding: 0;
+	text-align: center;
+	position: relative;
+`;
+
 const UpTo = styled.div`
 	margin-bottom: 0.2rem;
 	line-height: 1;
@@ -49,13 +56,7 @@ const Figure: React.FC<FigureProps> = ({
 	infoURL,
 }) => {
 	return (
-		<figure
-			style={{
-				textAlign: 'center',
-				position: 'relative',
-				fontSize: smaller ? '0.8rem' : '1rem',
-			}}
-		>
+		<Container style={{ fontSize: smaller ? '0.8rem' : '1rem' }}>
 			{showUpTo && <UpTo>UP TO</UpTo>}
 			<Amount style={{ color: color }}>
 				{new Intl.NumberFormat('en-US', {
@@ -77,7 +78,7 @@ const Figure: React.FC<FigureProps> = ({
 					</a>
 				)}
 			</Subtitle>
-		</figure>
+		</Container>
 	);
 };
 


### PR DESCRIPTION
Turns out the `<figure />` element includes built-in margin/padding. This was not intended to be used.