### PR TITLE
Shorten component test descriptors

### DIFF
--- a/src/components/app.test.tsx
+++ b/src/components/app.test.tsx
@@ -4,6 +4,6 @@ import { shallow } from 'enzyme';
 import App from './app';
 
 // Tests
-it('renders shallowly without crashing', () => {
+it('renders shallowly', () => {
 	shallow(<App />);
 });

--- a/src/components/choice.test.tsx
+++ b/src/components/choice.test.tsx
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import Choice from './choice';
 
 // Tests
-it('renders shallowly without crashing (simple)', () => {
+it('renders shallowly (simple)', () => {
 	shallow(
 		<Choice onChange={() => null} ariaLabel='ARIA label'>
 			<option>Option 1</option>
@@ -13,7 +13,7 @@ it('renders shallowly without crashing (simple)', () => {
 	);
 });
 
-it('renders shallowly without crashing (grouped)', () => {
+it('renders shallowly (grouped)', () => {
 	shallow(
 		<Choice onChange={() => null} ariaLabel='ARIA label'>
 			<optgroup label='Group 1'>
@@ -29,7 +29,7 @@ it('renders shallowly without crashing (grouped)', () => {
 	);
 });
 
-it('renders shallowly without crashing (some disabled)', () => {
+it('renders shallowly (some disabled)', () => {
 	shallow(
 		<Choice onChange={() => null} ariaLabel='ARIA label'>
 			<option disabled>Option 1</option>

--- a/src/components/choices.test.tsx
+++ b/src/components/choices.test.tsx
@@ -6,7 +6,7 @@ import store from '../redux/store';
 import { Provider } from 'react-redux';
 
 // Tests
-it('renders shallowly without crashing', () => {
+it('renders shallowly', () => {
 	shallow(
 		<Provider store={store}>
 			<Choices />

--- a/src/components/compensation.test.tsx
+++ b/src/components/compensation.test.tsx
@@ -6,7 +6,7 @@ import store from '../redux/store';
 import { Provider } from 'react-redux';
 
 // Tests
-it('renders shallowly without crashing', () => {
+it('renders shallowly', () => {
 	shallow(
 		<Provider store={store}>
 			<Compensation />

--- a/src/components/container.test.tsx
+++ b/src/components/container.test.tsx
@@ -4,6 +4,6 @@ import { shallow } from 'enzyme';
 import Container from './container';
 
 // Tests
-it('renders shallowly without crashing', () => {
+it('renders shallowly', () => {
 	shallow(<Container />);
 });

--- a/src/components/divider.test.tsx
+++ b/src/components/divider.test.tsx
@@ -4,6 +4,6 @@ import { shallow } from 'enzyme';
 import Divider from './divider';
 
 // Tests
-it('renders shallowly without crashing', () => {
+it('renders shallowly', () => {
 	shallow(<Divider text='example' />);
 });

--- a/src/components/figure.test.tsx
+++ b/src/components/figure.test.tsx
@@ -4,29 +4,29 @@ import { shallow } from 'enzyme';
 import Figure from './figure';
 
 // Tests
-it('renders shallowly without crashing (basic)', () => {
+it('renders shallowly (basic)', () => {
 	shallow(<Figure amount={123456} subtitle='EXAMPLE SUBTITLE' />);
 });
 
-it('renders shallowly without crashing (custom color)', () => {
+it('renders shallowly (custom color)', () => {
 	shallow(
 		<Figure amount={123456} subtitle='EXAMPLE SUBTITLE' color={'#f00'} />
 	);
 });
 
-it('renders shallowly without crashing (smaller)', () => {
+it('renders shallowly (smaller)', () => {
 	shallow(
 		<Figure amount={123456} subtitle='EXAMPLE SUBTITLE' smaller={true} />
 	);
 });
 
-it('renders shallowly without crashing (with up to)', () => {
+it('renders shallowly (with up to)', () => {
 	shallow(
 		<Figure amount={123456} subtitle='EXAMPLE SUBTITLE' showUpTo={true} />
 	);
 });
 
-it('renders shallowly without crashing (with info icon)', () => {
+it('renders shallowly (with info icon)', () => {
 	shallow(
 		<Figure
 			amount={123456}

--- a/src/components/footer.test.tsx
+++ b/src/components/footer.test.tsx
@@ -4,6 +4,6 @@ import { shallow } from 'enzyme';
 import Footer from './footer';
 
 // Tests
-it('renders shallowly without crashing', () => {
+it('renders shallowly', () => {
 	shallow(<Footer />);
 });

--- a/src/components/gradient.test.tsx
+++ b/src/components/gradient.test.tsx
@@ -4,6 +4,6 @@ import { shallow } from 'enzyme';
 import Gradient from './gradient';
 
 // Tests
-it('renders shallowly without crashing', () => {
+it('renders shallowly', () => {
 	shallow(<Gradient />);
 });

--- a/src/components/header.test.tsx
+++ b/src/components/header.test.tsx
@@ -4,6 +4,6 @@ import { shallow } from 'enzyme';
 import Header from './header';
 
 // Tests
-it('renders shallowly without crashing', () => {
+it('renders shallowly', () => {
 	shallow(<Header />);
 });

--- a/src/components/position-description.test.tsx
+++ b/src/components/position-description.test.tsx
@@ -6,7 +6,7 @@ import store from '../redux/store';
 import { Provider } from 'react-redux';
 
 // Tests
-it('renders shallowly without crashing', () => {
+it('renders shallowly', () => {
 	shallow(
 		<Provider store={store}>
 			<PositionDescription />


### PR DESCRIPTION
The "without crashing" part is pretty clear, given that's what the test suite is checking for. Therefore, this suffix on all the test descriptors is unnecessarily verbose.