### PR TITLE
Don't shallowly render <Provider /> component during testing

### DIFF
--- a/src/components/choices.test.tsx
+++ b/src/components/choices.test.tsx
@@ -1,15 +1,17 @@
 // Imports
 import React from 'react';
-import { shallow } from 'enzyme';
+import ReactDOM from 'react-dom';
 import Choices from './choices';
 import store from '../redux/store';
 import { Provider } from 'react-redux';
 
 // Tests
-it('renders shallowly', () => {
-	shallow(
+it('renders', () => {
+	const div = document.createElement('div');
+	ReactDOM.render(
 		<Provider store={store}>
 			<Choices />
-		</Provider>
+		</Provider>,
+		div
 	);
 });

--- a/src/components/compensation.test.tsx
+++ b/src/components/compensation.test.tsx
@@ -6,7 +6,7 @@ import store from '../redux/store';
 import { Provider } from 'react-redux';
 
 // Tests
-it('renders shallowly', () => {
+it('renders', () => {
 	const div = document.createElement('div');
 	ReactDOM.render(
 		<Provider store={store}>

--- a/src/components/compensation.test.tsx
+++ b/src/components/compensation.test.tsx
@@ -1,15 +1,17 @@
 // Imports
 import React from 'react';
-import { shallow } from 'enzyme';
+import ReactDOM from 'react-dom';
 import Compensation from './compensation';
 import store from '../redux/store';
 import { Provider } from 'react-redux';
 
 // Tests
 it('renders shallowly', () => {
-	shallow(
+	const div = document.createElement('div');
+	ReactDOM.render(
 		<Provider store={store}>
 			<Compensation />
-		</Provider>
+		</Provider>,
+		div
 	);
 });

--- a/src/components/position-description.test.tsx
+++ b/src/components/position-description.test.tsx
@@ -1,15 +1,17 @@
 // Imports
 import React from 'react';
-import { shallow } from 'enzyme';
+import ReactDOM from 'react-dom';
 import PositionDescription from './position-description';
 import store from '../redux/store';
 import { Provider } from 'react-redux';
 
 // Tests
 it('renders shallowly', () => {
-	shallow(
+	const div = document.createElement('div');
+	ReactDOM.render(
 		<Provider store={store}>
 			<PositionDescription />
-		</Provider>
+		</Provider>,
+		div
 	);
 });

--- a/src/components/position-description.test.tsx
+++ b/src/components/position-description.test.tsx
@@ -6,7 +6,7 @@ import store from '../redux/store';
 import { Provider } from 'react-redux';
 
 // Tests
-it('renders shallowly', () => {
+it('renders', () => {
 	const div = document.createElement('div');
 	ReactDOM.render(
 		<Provider store={store}>


### PR DESCRIPTION
Several of the tests were shallowing rendering components that needed to be wrapped in a `<Provider />` component. Effectively, then, we were only testing the `<Provider />` component from React-Redux, and not the component we actually built.