### PR TITLE
Improve how the icon wraps on iPhones and other popular devices

### DIFF
--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -238,7 +238,7 @@ exports[`Storyshots Compensation Normal 1`] = `
   className="container__Container-sc-8aaowj-0 bfnNcc"
 >
   <figure
-    className="figure__Container-sc-1fhptnd-0 kfKLc"
+    className="figure__Container-sc-1fhptnd-0 bpKHsn"
     style={
       Object {
         "fontSize": "1rem",
@@ -275,7 +275,7 @@ exports[`Storyshots Compensation Normal 1`] = `
   >
     <div>
       <figure
-        className="figure__Container-sc-1fhptnd-0 kfKLc"
+        className="figure__Container-sc-1fhptnd-0 bpKHsn"
         style={
           Object {
             "fontSize": "0.8rem",
@@ -314,7 +314,7 @@ exports[`Storyshots Compensation Normal 1`] = `
     </div>
     <div>
       <figure
-        className="figure__Container-sc-1fhptnd-0 kfKLc"
+        className="figure__Container-sc-1fhptnd-0 bpKHsn"
         style={
           Object {
             "fontSize": "0.8rem",
@@ -414,7 +414,7 @@ exports[`Storyshots Divider Normal 1`] = `
 
 exports[`Storyshots Figure Basic 1`] = `
 <figure
-  className="figure__Container-sc-1fhptnd-0 kfKLc"
+  className="figure__Container-sc-1fhptnd-0 bpKHsn"
   style={
     Object {
       "fontSize": "1rem",
@@ -441,7 +441,7 @@ exports[`Storyshots Figure Basic 1`] = `
 
 exports[`Storyshots Figure Custom Color 1`] = `
 <figure
-  className="figure__Container-sc-1fhptnd-0 kfKLc"
+  className="figure__Container-sc-1fhptnd-0 bpKHsn"
   style={
     Object {
       "fontSize": "1rem",
@@ -468,7 +468,7 @@ exports[`Storyshots Figure Custom Color 1`] = `
 
 exports[`Storyshots Figure Info Icon 1`] = `
 <figure
-  className="figure__Container-sc-1fhptnd-0 kfKLc"
+  className="figure__Container-sc-1fhptnd-0 bpKHsn"
   style={
     Object {
       "fontSize": "1rem",
@@ -505,7 +505,7 @@ exports[`Storyshots Figure Info Icon 1`] = `
 
 exports[`Storyshots Figure Smaller 1`] = `
 <figure
-  className="figure__Container-sc-1fhptnd-0 kfKLc"
+  className="figure__Container-sc-1fhptnd-0 bpKHsn"
   style={
     Object {
       "fontSize": "0.8rem",
@@ -532,7 +532,7 @@ exports[`Storyshots Figure Smaller 1`] = `
 
 exports[`Storyshots Figure Up To 1`] = `
 <figure
-  className="figure__Container-sc-1fhptnd-0 kfKLc"
+  className="figure__Container-sc-1fhptnd-0 bpKHsn"
   style={
     Object {
       "fontSize": "1rem",

--- a/src/components/figure.tsx
+++ b/src/components/figure.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components/macro';
 // Styled elements
 const Container = styled.figure`
 	margin: 0;
-	padding: 0;
+	padding: 0 0.5em;
 	text-align: center;
 	position: relative;
 `;


### PR DESCRIPTION
On most iPhones, here's the difference:

### Before
<img width="333" alt="Screen Shot 2020-11-20 at 11 03 27 AM" src="https://user-images.githubusercontent.com/3850064/99828023-06ebda00-2b20-11eb-9fff-f7dd865bad6f.png">

### After
<img width="313" alt="Screen Shot 2020-11-20 at 11 02 51 AM" src="https://user-images.githubusercontent.com/3850064/99827970-f0458300-2b1f-11eb-9c4a-7c9403230a0a.png">