### PR TITLE
Improve title appearance on mobile

### DIFF
--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -609,7 +609,7 @@ exports[`Storyshots Gradient Normal 1`] = `
 exports[`Storyshots Header Normal 1`] = `
 <header>
   <h1
-    className="header__Title-vob98y-0 iYxVKp"
+    className="header__Title-vob98y-0 jcfmoo"
   >
     Sparksuite’s Salary Calculator
   </h1>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -7,11 +7,13 @@ const Title = styled.h1`
 	margin: 0;
 	padding: 0;
 	margin-top: 3.5rem;
+	margin-bottom: 0.1em;
 	color: #fff;
 	font-family: Playfair Display, serif;
 	font-weight: 700;
 	font-size: 2.5rem;
 	text-shadow: 0.1rem 0.1rem 0.25rem rgba(0, 0, 0, 0.1);
+	line-height: 1.1;
 `;
 
 const Subtitle = styled.h2`


### PR DESCRIPTION
There's less line spacing between "Sparksuite’s" and "salary calculator."

Before | After
:--- | :---
<img width="380" alt="Screen Shot 2020-11-24 at 12 03 03 PM" src="https://user-images.githubusercontent.com/3850064/100134442-d5d81600-2e4d-11eb-960c-feee7ca03331.png"> | <img width="381" alt="Screen Shot 2020-11-24 at 12 02 53 PM" src="https://user-images.githubusercontent.com/3850064/100134455-d8d30680-2e4d-11eb-8565-8b06ee98aed0.png">
