### PR TITLE
Bump up office assistant salary

### DIFF
--- a/src/data.json
+++ b/src/data.json
@@ -130,7 +130,7 @@
 						{
 							"title": "Office assistant",
 							"description": "An office assistant helps in a multitude of ways around our office, ensuring it runs smoothly and that our whole team is able to work efficiently.",
-							"startingSalary": 30000,
+							"startingSalary": 35000,
 							"annualRaises": [0.05, 0.035, 0.03, 0.025, 0.02, 0.02]
 						}
 					]


### PR DESCRIPTION
This brings the starting pay for the office assistant position from $30,000/year to $35,000/yr.