### PR TITLE
Introduce revamped benefits

### DIFF
--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -167,28 +167,7 @@ exports[`Storyshots Choices Normal 1`] = `
   <span
     className="choices__Text-sc-800kf9-1 bhMwJj"
   >
-    and, for health benefits, I
-  </span>
-  <div
-    className="choice__Wrapper-sc-1k1omlp-0 csOUzD"
-  >
-    <select
-      aria-label="Spouse or dependents"
-      className="choice__Select-sc-1k1omlp-1 cBdpEX"
-      onChange={[Function]}
-    >
-      <option>
-        don’t
-      </option>
-      <option>
-        do
-      </option>
-    </select>
-  </div>
-  <span
-    className="choices__Text-sc-800kf9-1 bhMwJj"
-  >
-    have a spouse / dependents. I’ve been 
+    and have been 
     an engineer
      in the Sparksuite family for
   </span>
@@ -261,7 +240,7 @@ exports[`Storyshots Compensation Normal 1`] = `
         }
       }
     >
-      $85,000
+      $88,000
     </div>
     <figcaption
       className="figure__Subtitle-sc-1fhptnd-3 bfewYL"
@@ -298,12 +277,12 @@ exports[`Storyshots Compensation Normal 1`] = `
             }
           }
         >
-          $4,800
+          50%
         </div>
         <figcaption
           className="figure__Subtitle-sc-1fhptnd-3 bfewYL"
         >
-          TAX-FREE HRA FUNDS
+          OF BASE HEALTH PLAN PREMIUM
           <a
             aria-label="Learn more"
             href="https://handbook.sparksuite.com/benefits/health.html"
@@ -317,7 +296,14 @@ exports[`Storyshots Compensation Normal 1`] = `
         </figcaption>
       </figure>
       <p>
-        Flexible funds that reimburse you for nearly any health-related expense, including insurance premiums, deductibles, copayments, coinsurance, eyeglasses, sunscreen, and so much more.
+        Company contribution of 50% of the cost of your base health plan’s premium toward any of the health plans offered. We also offer vision and dental plans, plus
+         
+        <span
+          className="compensation__AvoidLineBreakWithin-sc-1127ja8-1 gHGKlE"
+        >
+          HSAs and FSAs
+        </span>
+         to help reduce your taxes.
       </p>
     </div>
     <div>
@@ -342,7 +328,7 @@ exports[`Storyshots Compensation Normal 1`] = `
             }
           }
         >
-          $3,400
+          $3,520
         </div>
         <figcaption
           className="figure__Subtitle-sc-1fhptnd-3 bfewYL"
@@ -375,7 +361,7 @@ exports[`Storyshots Compensation Normal 1`] = `
     </div>
   </div>
   <div
-    className="compensation__Perks-sc-1127ja8-1 eyDTrZ"
+    className="compensation__Perks-sc-1127ja8-2 jeuOJy"
   >
     Flexible working hours, free-lunch Fridays, generous paid time off, healthy work-life balance, craft coffee, and all these other
      

--- a/src/components/choices.tsx
+++ b/src/components/choices.tsx
@@ -109,18 +109,7 @@ const Choices: React.FC = () => {
 					</optgroup>
 				))}
 			</Choice>
-			<Text>and, for health benefits, I</Text>
-			<Choice
-				onChange={(value: string) => dispatch(actions.setDependents(value))}
-				ariaLabel='Spouse or dependents'
-			>
-				<option>don’t</option>
-				<option>do</option>
-			</Choice>
-			<Text>
-				have a spouse / dependents. I’ve been {fieldDescriptor} in the
-				Sparksuite family for
-			</Text>
+			<Text>and have been {fieldDescriptor} in the Sparksuite family for</Text>
 			<Choice
 				onChange={(value: string) => dispatch(actions.setTenure(value))}
 				ariaLabel='Tenure'

--- a/src/components/compensation.tsx
+++ b/src/components/compensation.tsx
@@ -39,6 +39,10 @@ const FlexDiv = styled.div`
 	}
 `;
 
+const AvoidLineBreakWithin = styled.span`
+	display: inline-block;
+`;
+
 const Perks = styled.div`
 	max-width: 450px;
 	margin: 2rem auto 0;
@@ -82,14 +86,6 @@ const Compensation: React.FC = () => {
 		selectedTenure
 	);
 
-	// Determine HRA funding amount
-	const hasDependents = useSelector((state: AppState) => state.dependents);
-	let hraFunding = 4800;
-
-	if (hasDependents) {
-		hraFunding = 9600;
-	}
-
 	// Return JSX
 	return (
 		<Container>
@@ -100,17 +96,19 @@ const Compensation: React.FC = () => {
 			<FlexDiv>
 				<div>
 					<Figure
-						amount={hraFunding}
-						subtitle='TAX-FREE HRA FUNDS'
+						amount='50%'
+						subtitle='OF BASE HEALTH PLAN PREMIUM'
 						color='#67b1d6'
 						smaller={true}
 						infoURL='https://handbook.sparksuite.com/benefits/health.html'
 					/>
 
 					<p>
-						Flexible funds that reimburse you for nearly any health-related
-						expense, including insurance premiums, deductibles, copayments,
-						coinsurance, eyeglasses, sunscreen, and so much more.
+						Company contribution of 50% of the cost of your base health plan’s
+						premium toward any of the health plans offered. We also offer vision
+						and dental plans, plus{' '}
+						<AvoidLineBreakWithin>HSAs and FSAs</AvoidLineBreakWithin> to help
+						reduce your taxes.
 					</p>
 				</div>
 

--- a/src/components/figure.tsx
+++ b/src/components/figure.tsx
@@ -38,7 +38,7 @@ const Subtitle = styled.figcaption`
 
 // Define the component props
 type Props = {
-	amount: number;
+	amount: number | string;
 	subtitle: string;
 	color?: string;
 	smaller?: boolean;
@@ -58,13 +58,17 @@ const Figure: React.FC<Props> = ({
 	return (
 		<Container style={{ fontSize: smaller ? '0.8rem' : '1rem' }}>
 			{showUpTo && <UpTo>UP TO</UpTo>}
-			<Amount style={{ color: color }}>
-				{new Intl.NumberFormat('en-US', {
-					style: 'currency',
-					currency: 'USD',
-					minimumFractionDigits: 0,
-				}).format(amount)}
-			</Amount>
+			{typeof amount === 'number' ? (
+				<Amount style={{ color: color }}>
+					{new Intl.NumberFormat('en-US', {
+						style: 'currency',
+						currency: 'USD',
+						minimumFractionDigits: 0,
+					}).format(amount)}
+				</Amount>
+			) : (
+				<Amount style={{ color: color }}>{amount}</Amount>
+			)}
 			<Subtitle>
 				{subtitle}
 				{infoURL && (

--- a/src/data.json
+++ b/src/data.json
@@ -19,31 +19,31 @@
 						{
 							"title": "Front End Engineer I",
 							"description": "A level one front end engineer is usually just beginning their professional career in front end software engineering and is developing a strong foundational knowledge of the fundamentals and familiarity with the technologies they use. They’re capable of completing tasks given to them with some direction and oversight. Reviews typically require more iterations to achieve high quality, intuitive, and polished code contributions.",
-							"startingSalary": 85000,
+							"startingSalary": 88000,
 							"annualRaises": [0.1]
 						},
 						{
 							"title": "Front End Engineer II",
 							"description": "A level two front end engineer has relevant professional experience and has developed a strong understanding of software engineering fundamentals. They require less direction to accomplish tasks and are beginning to take more initiative to propose contributions and design solutions to problems. Reviews generally require fewer iterations before being accepted. Level two engineers have grown in efficiency and can tackle more complex problems with less direction. Their expertise with browser technologies, performance measuring, accessibility testing, and other front end specific knowledge is expanding. Their eye for UI/UX is developing as they learn how to refine the front end experiences they produce.",
-							"startingSalary": 92500,
+							"startingSalary": 95500,
 							"annualRaises": [0.075, 0.05, 0.03]
 						},
 						{
 							"title": "Front End Engineer III",
 							"description": "A level three front end engineer typically has several years of relevant professional experience and has honed their skills on a wide variety of topics related to front end engineering. They have a solid understanding of software engineering fundamentals and are beginning to be seen as a knowledge source by their teammates. Little direction is needed to accomplish tasks and they can tackle changes efficiently. The code they contribute is effective and well written, requiring very few review iterations. They often propose contributions and can effectively design solutions to more complex problems. They are well experienced with browser technologies, performance measuring, and accessibility testing, among other front end knowledge areas. They have an eye for UI/UX and are talented at refining the front end experiences they produce.",
-							"startingSalary": 100000,
+							"startingSalary": 103000,
 							"annualRaises": [0.05, 0.035, 0.03, 0.025, 0.02, 0.02]
 						},
 						{
 							"title": "Senior Front End Engineer",
 							"description": "A senior front end engineer—the first step on the contributor track—is a talented and efficient individual contributor with substantial professional experience. They produce effective, intuitive, and polished code contributions that require little-to-no review iterations. Given their deep familiarity with the technologies they use, they are seen as a technical guru by their teammates. They are often trusted to design skillful solutions to complex problems and dependably propose contributions.",
-							"startingSalary": 110000,
+							"startingSalary": 113000,
 							"annualRaises": [0.05, 0.035, 0.03, 0.025, 0.02, 0.02]
 						},
 						{
 							"title": "Lead Front End Engineer",
 							"description": "A lead front end engineer—the first step on the leadership track—is a highly experienced front end engineer with a knack for producing great work in others. While also being a strong individual contributor, lead engineers are beginning to incorporate leadership responsibilities into their role, like reviewing their teammates’ contributions, assigning tasks, and directing smaller projects. They assist with hiring and training new team members and provide guidance to less experienced teammates.",
-							"startingSalary": 110000,
+							"startingSalary": 113000,
 							"annualRaises": [0.05, 0.035, 0.03, 0.025, 0.02, 0.02]
 						}
 					]
@@ -54,31 +54,31 @@
 						{
 							"title": "Back End Engineer I",
 							"description": "A level one back end engineer is usually just beginning their professional career in back end software engineering and is developing a strong foundational knowledge of the fundamentals and familiarity with the technologies they use. They’re capable of completing tasks given to them with some direction and oversight. Reviews typically require more iterations to achieve high quality, intuitive, and polished code contributions.",
-							"startingSalary": 77500,
+							"startingSalary": 80500,
 							"annualRaises": [0.1]
 						},
 						{
 							"title": "Back End Engineer II",
 							"description": "A level two back end engineer has relevant professional experience and has developed a strong understanding of software engineering fundamentals. They require less direction to accomplish tasks and are beginning to take more initiative to propose contributions and design solutions to problems. Reviews generally require fewer iterations before being accepted. Level two engineers have grown in efficiency and can tackle more complex problems with less direction. Their expertise with network requests, database design, microservice design, performance optimizations, and other back end specific knowledge is expanding.",
-							"startingSalary": 85000,
+							"startingSalary": 88000,
 							"annualRaises": [0.075, 0.05, 0.03]
 						},
 						{
 							"title": "Back End Engineer III",
 							"description": "A level three back end engineer typically has several years of relevant professional experience and has honed their skills on a wide variety of topics related to back end engineering. They have a solid understanding of software engineering fundamentals and are beginning to be seen as a knowledge source by their teammates. Little direction is needed to accomplish tasks and they can tackle changes efficiently. The code they contribute is effective and well written, requiring very few review iterations. They often propose contributions and can effectively design solutions to more complex problems. They are well experienced with network requests, database design, microservice design, and performance optimizations, among other back end knowledge areas.",
-							"startingSalary": 92500,
+							"startingSalary": 95500,
 							"annualRaises": [0.05, 0.035, 0.03, 0.025, 0.02, 0.02]
 						},
 						{
 							"title": "Senior Back End Engineer",
 							"description": "A senior back end engineer—the first step on the contributor track—is a talented and efficient individual contributor with substantial professional experience. They produce effective, intuitive, and polished code contributions that require little-to-no review iterations. Given their deep familiarity with the technologies they use, they are seen as a technical guru by their teammates. They are often trusted to design skillful solutions to complex problems and dependably propose contributions.",
-							"startingSalary": 102500,
+							"startingSalary": 105500,
 							"annualRaises": [0.05, 0.035, 0.03, 0.025, 0.02, 0.02]
 						},
 						{
 							"title": "Lead Back End Engineer",
 							"description": "A lead back end engineer—the first step on the leadership track—is a highly experienced back end engineer with a knack for producing great work in others. While also being a strong individual contributor, lead engineers are beginning to incorporate leadership responsibilities into their role, like reviewing their teammates’ contributions, assigning tasks, and directing smaller projects. They assist with hiring and training new team members and provide guidance to less experienced teammates.",
-							"startingSalary": 102500,
+							"startingSalary": 105500,
 							"annualRaises": [0.05, 0.035, 0.03, 0.025, 0.02, 0.02]
 						}
 					]
@@ -89,31 +89,31 @@
 						{
 							"title": "DevOps Engineer I",
 							"description": "A level one DevOps engineer is usually just beginning their professional career in DevOps software engineering and is developing a strong foundational knowledge of the fundamentals and familiarity with the technologies they use. They’re capable of completing tasks given to them with some direction and oversight. Reviews typically require more iterations to achieve high quality, intuitive, and polished code contributions.",
-							"startingSalary": 82500,
+							"startingSalary": 85500,
 							"annualRaises": [0.1]
 						},
 						{
 							"title": "DevOps Engineer II",
 							"description": "A level two DevOps engineer has relevant professional experience and has developed a strong understanding of software engineering fundamentals. They require less direction to accomplish tasks and are beginning to take more initiative to propose contributions and design solutions to problems. Reviews generally require fewer iterations before being accepted. Level two engineers have grown in efficiency and can tackle more complex problems with less direction. Their expertise with Kubernetes, CI/CD pipelines, CLI design, performance optimizations, and other DevOps specific knowledge is expanding.",
-							"startingSalary": 90000,
+							"startingSalary": 93000,
 							"annualRaises": [0.075, 0.05, 0.03]
 						},
 						{
 							"title": "DevOps Engineer III",
 							"description": "A level three DevOps engineer typically has several years of relevant professional experience and has honed their skills on a wide variety of topics related to DevOps engineering. They have a solid understanding of software engineering fundamentals and are beginning to be seen as a knowledge source by their teammates. Little direction is needed to accomplish tasks and they can tackle changes efficiently. The code they contribute is effective and well written, requiring very few review iterations. They often propose contributions and can effectively design solutions to more complex problems. They are well experienced with Kubernetes, CI/CD pipelines, CLI design, and performance optimizations, among other DevOps knowledge areas.",
-							"startingSalary": 97500,
+							"startingSalary": 100500,
 							"annualRaises": [0.05, 0.035, 0.03, 0.025, 0.02, 0.02]
 						},
 						{
 							"title": "Senior DevOps Engineer",
 							"description": "A senior DevOps engineer—the first step on the contributor track—is a talented and efficient individual contributor with substantial professional experience. They produce effective, intuitive, and polished code contributions that require little-to-no review iterations. Given their deep familiarity with the technologies they use, they are seen as a technical guru by their teammates. They are often trusted to design skillful solutions to complex problems and dependably propose contributions.",
-							"startingSalary": 107500,
+							"startingSalary": 110500,
 							"annualRaises": [0.05, 0.035, 0.03, 0.025, 0.02, 0.02]
 						},
 						{
 							"title": "Lead DevOps Engineer",
 							"description": "A lead DevOps engineer—the first step on the leadership track—is a highly experienced DevOps engineer with a knack for producing great work in others. While also being a strong individual contributor, lead engineers are beginning to incorporate leadership responsibilities into their role, like reviewing their teammates’ contributions, assigning tasks, and directing smaller projects. They assist with hiring and training new team members and provide guidance to less experienced teammates.",
-							"startingSalary": 107500,
+							"startingSalary": 110500,
 							"annualRaises": [0.05, 0.035, 0.03, 0.025, 0.02, 0.02]
 						}
 					]
@@ -130,25 +130,25 @@
 						{
 							"title": "Customer Success Champion I",
 							"description": "A level one customer success champion has relevant work experience in customer service oriented roles, is a strong communicator, and is personable. They’re tech-savvy enough to understand new technologies quickly and are developing a familiarity with the product and technologies used. They’re capable of interacting with customers and completing work with some direction and oversight, with some review needed to achieve high quality output.",
-							"startingSalary": 45000,
+							"startingSalary": 48000,
 							"annualRaises": [0.1]
 						},
 						{
 							"title": "Customer Success Champion II",
 							"description": "A level two customer success champion has extensive work experience in customer success roles, excellent communication skills, and is exceedingly personable. Their understanding and familiarity of the product and technologies used are expanding, and they can tackle more complex situations with less direction. Their work has grown in efficiency and typically requires fewer modifications to meet our team’s high standards of quality. Level two customer success champions also are beginning to take more initiative to solve problems, help other members, and propose new ideas.",
-							"startingSalary": 49000,
+							"startingSalary": 52000,
 							"annualRaises": [0.075, 0.05, 0.03, 0.025, 0.02, 0.02]
 						},
 						{
 							"title": "Senior Customer Success Champion",
 							"description": "A senior customer success champion—the first step on the contributor track—is a talented individual contributor with substantial professional experience. They have a deep familiarity with the product and technologies used and are viewed as an expert by their team. Their work is efficient and high quality, requiring little-to-no review. They help guide less experienced team members, develop content, and are trusted to solve complex problems.",
-							"startingSalary": 54500,
+							"startingSalary": 57500,
 							"annualRaises": [0.05, 0.035, 0.03, 0.025, 0.02, 0.02]
 						},
 						{
 							"title": "Lead Customer Success Champion",
 							"description": "A lead customer success champion—the first step on the leadership track—is highly experienced and has a knack for producing great work in others. While being a strong individual contributor, they also have leadership responsibilities. Among other things, this includes reviewing the performance of those who report to them, assisting with hiring and training new team members, providing guidance, and ensuring team goals are achieved.",
-							"startingSalary": 54500,
+							"startingSalary": 57500,
 							"annualRaises": [0.05, 0.035, 0.03, 0.025, 0.02, 0.02]
 						}
 					]
@@ -165,7 +165,7 @@
 						{
 							"title": "Office assistant",
 							"description": "An office assistant helps in a multitude of ways around our office, ensuring it runs smoothly and that our whole team is able to work efficiently.",
-							"startingSalary": 35000,
+							"startingSalary": 38000,
 							"annualRaises": [0.05, 0.035, 0.03, 0.025, 0.02, 0.02]
 						}
 					]

--- a/src/redux/actions.ts
+++ b/src/redux/actions.ts
@@ -1,19 +1,11 @@
 // Imports
-import { SET_POSITION, SET_DEPENDENTS, SET_TENURE, ChoiceTypes } from './types';
+import { SET_POSITION, SET_TENURE, ChoiceTypes } from './types';
 
 // Set the position
 export function setPosition(value: string): ChoiceTypes {
 	return {
 		type: SET_POSITION,
 		value,
-	};
-}
-
-// Set whether they have a spouse/dependents
-export function setDependents(value: string): ChoiceTypes {
-	return {
-		type: SET_DEPENDENTS,
-		value: value === 'do',
 	};
 }
 

--- a/src/redux/reducer.ts
+++ b/src/redux/reducer.ts
@@ -1,17 +1,10 @@
 // Imports
 import data from '../data.json';
-import {
-	AppState,
-	SET_POSITION,
-	SET_DEPENDENTS,
-	SET_TENURE,
-	ChoiceTypes,
-} from './types';
+import { AppState, SET_POSITION, SET_TENURE, ChoiceTypes } from './types';
 
 // Define initial state
 const initialState: AppState = {
 	position: data.fields[0].roles[0].levels[0].title,
-	dependents: false,
 	tenure: data.tenures[0],
 };
 
@@ -25,11 +18,6 @@ export default function reducer(
 			return {
 				...state,
 				position: action.value,
-			};
-		case SET_DEPENDENTS:
-			return {
-				...state,
-				dependents: action.value,
 			};
 		case SET_TENURE:
 			return {

--- a/src/redux/types.ts
+++ b/src/redux/types.ts
@@ -1,7 +1,6 @@
 // Export initial state interface
 export interface AppState {
 	position: string;
-	dependents: boolean;
 	tenure: string;
 }
 
@@ -12,12 +11,6 @@ interface SetPositionAction {
 	value: string;
 }
 
-export const SET_DEPENDENTS = 'SET_DEPENDENTS';
-interface SetDependentsAction {
-	type: typeof SET_DEPENDENTS;
-	value: boolean;
-}
-
 export const SET_TENURE = 'SET_TENURE';
 interface SetTenureAction {
 	type: typeof SET_TENURE;
@@ -25,7 +18,4 @@ interface SetTenureAction {
 }
 
 // Export union type
-export type ChoiceTypes =
-	| SetPositionAction
-	| SetDependentsAction
-	| SetTenureAction;
+export type ChoiceTypes = SetPositionAction | SetTenureAction;


### PR DESCRIPTION
This PR updates our salary calculator in light of the revamped benefits expected to arrive March 1, 2022 (more info in [this PR](https://github.com/sparksuite/employee-handbook/pull/3) from our transparent employee handbook).

Based on feedback from our team, we’ve chosen to minimize the company contribution toward health insurance premiums, and instead raise all starting salaries by $3,000/yr. This compensation structure gives team members the flexibility to continue putting tax-free earnings toward insurance premiums, or, if their health expenses happen to be low, use the raise to spend on anything else they’re interested in, like hobbies, travel, etc.