### PR TITLE
Fix `text-overflow: ellipsis` CSS rule

### DIFF
--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -6,7 +6,7 @@ exports[`Storyshots Choice Grouped 1`] = `
 >
   <select
     aria-label="ARIA label"
-    className="choice__Select-sc-1k1omlp-1 gqMQcq"
+    className="choice__Select-sc-1k1omlp-1 zxzDb"
     onChange={[Function]}
   >
     <optgroup
@@ -42,7 +42,7 @@ exports[`Storyshots Choice Simple 1`] = `
 >
   <select
     aria-label="ARIA label"
-    className="choice__Select-sc-1k1omlp-1 gqMQcq"
+    className="choice__Select-sc-1k1omlp-1 zxzDb"
     onChange={[Function]}
   >
     <option>
@@ -64,7 +64,7 @@ exports[`Storyshots Choice Some Disabled 1`] = `
 >
   <select
     aria-label="ARIA label"
-    className="choice__Select-sc-1k1omlp-1 gqMQcq"
+    className="choice__Select-sc-1k1omlp-1 zxzDb"
     onChange={[Function]}
   >
     <option
@@ -96,7 +96,7 @@ exports[`Storyshots Choices Normal 1`] = `
   >
     <select
       aria-label="Position"
-      className="choice__Select-sc-1k1omlp-1 gqMQcq"
+      className="choice__Select-sc-1k1omlp-1 zxzDb"
       onChange={[Function]}
     >
       <optgroup
@@ -188,7 +188,7 @@ exports[`Storyshots Choices Normal 1`] = `
   >
     <select
       aria-label="Tenure"
-      className="choice__Select-sc-1k1omlp-1 gqMQcq"
+      className="choice__Select-sc-1k1omlp-1 zxzDb"
       onChange={[Function]}
       value="less than one year"
     >

--- a/src/components/choice.tsx
+++ b/src/components/choice.tsx
@@ -43,6 +43,8 @@ const Select = styled.select`
 	cursor: pointer;
 	text-overflow: ellipsis;
 	max-width: 50vw;
+	overflow: hidden;
+	white-space: nowrap;
 
 	/* For Windows */
 	option,


### PR DESCRIPTION
For an explanation of why: https://stackoverflow.com/a/17783233. Only works if these two rules are also present.

Before, it would clip only some of the roman numerals without an ellipsis on Safari, iOS, iPadOS, etc. (see below).

![56352](https://user-images.githubusercontent.com/3850064/153950388-4e75bf02-da69-4ebb-8c35-567788902125.jpg)
