### PR TITLE
Fix subtitle line breaking on mobile

### DIFF
--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -258,7 +258,7 @@ exports[`Storyshots Compensation Normal 1`] = `
       $88,000
     </div>
     <figcaption
-      className="figure__Subtitle-sc-1fhptnd-3 dUqReg"
+      className="figure__Subtitle-sc-1fhptnd-3 cidVDt"
     >
       ANNUAL SALARY
     </figcaption>
@@ -295,7 +295,7 @@ exports[`Storyshots Compensation Normal 1`] = `
           50%
         </div>
         <figcaption
-          className="figure__Subtitle-sc-1fhptnd-3 dUqReg"
+          className="figure__Subtitle-sc-1fhptnd-3 cidVDt"
         >
           OF BASE HEALTH PLAN PREMIUM
           <a
@@ -346,7 +346,7 @@ exports[`Storyshots Compensation Normal 1`] = `
           $3,520
         </div>
         <figcaption
-          className="figure__Subtitle-sc-1fhptnd-3 dUqReg"
+          className="figure__Subtitle-sc-1fhptnd-3 cidVDt"
         >
           MATCHING 401(k) CONTRIBUTIONS
           <a
@@ -504,7 +504,7 @@ exports[`Storyshots Figure Basic 1`] = `
     $123,456
   </div>
   <figcaption
-    className="figure__Subtitle-sc-1fhptnd-3 dUqReg"
+    className="figure__Subtitle-sc-1fhptnd-3 cidVDt"
   >
     EXAMPLE SUBTITLE
   </figcaption>
@@ -531,7 +531,7 @@ exports[`Storyshots Figure Custom Color 1`] = `
     $123,456
   </div>
   <figcaption
-    className="figure__Subtitle-sc-1fhptnd-3 dUqReg"
+    className="figure__Subtitle-sc-1fhptnd-3 cidVDt"
   >
     EXAMPLE SUBTITLE
   </figcaption>
@@ -558,7 +558,7 @@ exports[`Storyshots Figure Info Icon 1`] = `
     $123,456
   </div>
   <figcaption
-    className="figure__Subtitle-sc-1fhptnd-3 dUqReg"
+    className="figure__Subtitle-sc-1fhptnd-3 cidVDt"
   >
     EXAMPLE SUBTITLE
     <a
@@ -595,7 +595,7 @@ exports[`Storyshots Figure Smaller 1`] = `
     $123,456
   </div>
   <figcaption
-    className="figure__Subtitle-sc-1fhptnd-3 dUqReg"
+    className="figure__Subtitle-sc-1fhptnd-3 cidVDt"
   >
     EXAMPLE SUBTITLE
   </figcaption>
@@ -627,7 +627,7 @@ exports[`Storyshots Figure Up To 1`] = `
     $123,456
   </div>
   <figcaption
-    className="figure__Subtitle-sc-1fhptnd-3 dUqReg"
+    className="figure__Subtitle-sc-1fhptnd-3 cidVDt"
   >
     EXAMPLE SUBTITLE
   </figcaption>

--- a/src/components/figure.tsx
+++ b/src/components/figure.tsx
@@ -34,6 +34,10 @@ const Subtitle = styled.figcaption`
 		margin-left: 0.3rem;
 		color: #bdbdbd;
 	}
+
+	@media (max-width: 425px) {
+		font-size: 1.1em;
+	}
 `;
 
 // Define the component props


### PR DESCRIPTION
The `<Figure />` component's subtitle had a tendency to break on mobile devices in such a way that the "info" icon appeared on its own line. This was fixed by reducing the subtitle's font size on very small screens.

### Before

<img width="377" alt="Screenshot" src="https://user-images.githubusercontent.com/3850064/154070968-2feef01c-ae33-4e13-81b8-a1f14edd5a1c.jpg">

### After

<img width="377" alt="Screenshot" src="https://user-images.githubusercontent.com/3850064/154070951-2eec731c-55cb-4a95-834a-f9873aa0fd13.png">