### PR TITLE
Refactor prefilling the position

### DIFF
--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -97,8 +97,15 @@ exports[`Storyshots Choices Normal 1`] = `
     <select
       aria-label="Position"
       className="sc-eCImPb jKohRv"
+      defaultValue="PLACEHOLDER"
       onChange={[Function]}
     >
+      <option
+        disabled={true}
+        value="PLACEHOLDER"
+      >
+        select position…
+      </option>
       <optgroup
         label="Engineering"
       >
@@ -195,7 +202,7 @@ exports[`Storyshots Choices Normal 1`] = `
     className="sc-gKclnd fRIwcw"
   >
     and have been 
-    an engineer
+    
      in the Sparksuite family for
   </span>
   <div
@@ -270,7 +277,7 @@ exports[`Storyshots Compensation Normal 1`] = `
         }
       }
     >
-      $88,000
+      $--,---
     </div>
     <figcaption
       className="sc-kDTinF fvWamc"
@@ -358,7 +365,7 @@ exports[`Storyshots Compensation Normal 1`] = `
             }
           }
         >
-          $3,520
+          $-,---
         </div>
         <figcaption
           className="sc-kDTinF fvWamc"
@@ -722,6 +729,8 @@ exports[`Storyshots Position description Normal 1`] = `
 <div
   className="sc-iCfMLu QDVzU"
 >
-  A level one front end engineer is usually just beginning their professional career in front end software engineering and is developing a strong foundational knowledge of the fundamentals and familiarity with the technologies they use. They’re capable of completing tasks given to them with some direction and oversight. Reviews typically require more iterations to achieve high quality, intuitive, and polished code contributions.
+  <em>
+    Select a position above to see its description.
+  </em>
 </div>
 `;

--- a/src/components/choice.tsx
+++ b/src/components/choice.tsx
@@ -70,16 +70,24 @@ type Props = {
 	onChange: Function;
 	ariaLabel?: string;
 	value?: string;
+	defaultValue?: string;
 };
 
 // Functional component
-const Choice: React.FC<Props> = ({ onChange, ariaLabel, value, children }) => {
+const Choice: React.FC<Props> = ({
+	onChange,
+	ariaLabel,
+	value,
+	defaultValue,
+	children,
+}) => {
 	return (
 		<Wrapper>
 			<Select
 				onChange={(event) => onChange(event.target.value)}
 				aria-label={ariaLabel}
 				value={value}
+				defaultValue={defaultValue}
 			>
 				{children}
 			</Select>

--- a/src/components/choices.tsx
+++ b/src/components/choices.tsx
@@ -101,6 +101,10 @@ const Choices: React.FC = () => {
 				onChange={(value: string) => dispatch(actions.setPosition(value))}
 				ariaLabel='Position'
 			>
+				<option disabled selected>
+					select position…
+				</option>
+
 				{fields.map((field) => (
 					<optgroup key={field.descriptor} label={field.descriptor}>
 						{field.positions.map((position) => (

--- a/src/components/choices.tsx
+++ b/src/components/choices.tsx
@@ -1,5 +1,5 @@
 // Imports
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components/macro';
 import Choice from './choice';
 import data from '../data.json';
@@ -33,6 +33,24 @@ const Text = styled.span`
 const Choices: React.FC = () => {
 	// Use dispatch
 	const dispatch = useDispatch();
+
+	// Set the position if the corresponding search param is provided
+	useEffect(() => {
+		const searchParams = new URLSearchParams(window.location.search);
+		const requestedPosition = searchParams.get('position');
+
+		if (requestedPosition) {
+			for (const field of data.fields) {
+				for (const role of field.roles) {
+					for (const level of role.levels) {
+						if (level.title === requestedPosition) {
+							dispatch(actions.setPosition(requestedPosition));
+						}
+					}
+				}
+			}
+		}
+	}, []);
 
 	// Form an array of all position titles
 	let fields = [];
@@ -100,6 +118,7 @@ const Choices: React.FC = () => {
 			<Choice
 				onChange={(value: string) => dispatch(actions.setPosition(value))}
 				ariaLabel='Position'
+				value={selectedPosition}
 			>
 				<option disabled selected>
 					select position…

--- a/src/components/choices.tsx
+++ b/src/components/choices.tsx
@@ -50,7 +50,7 @@ const Choices: React.FC = () => {
 				}
 			}
 		}
-	}, []);
+	}, [dispatch]);
 
 	// Form an array of all position titles
 	let fields = [];
@@ -119,8 +119,9 @@ const Choices: React.FC = () => {
 				onChange={(value: string) => dispatch(actions.setPosition(value))}
 				ariaLabel='Position'
 				value={selectedPosition}
+				defaultValue='PLACEHOLDER'
 			>
-				<option disabled selected>
+				<option disabled value={'PLACEHOLDER'}>
 					select position…
 				</option>
 

--- a/src/components/compensation.tsx
+++ b/src/components/compensation.tsx
@@ -116,7 +116,10 @@ const Compensation: React.FC = () => {
 	// Return JSX
 	return (
 		<Container>
-			<Figure amount={annualSalary} subtitle='ANNUAL SALARY' />
+			<Figure
+				amount={selectedPosition ? annualSalary : '$--,---'}
+				subtitle='ANNUAL SALARY'
+			/>
 
 			<Divider text='plus' />
 
@@ -141,7 +144,7 @@ const Compensation: React.FC = () => {
 
 				<div>
 					<Figure
-						amount={annualSalary * 0.04}
+						amount={selectedPosition ? annualSalary * 0.04 : '$-,---'}
 						subtitle='MATCHING 401(k) CONTRIBUTIONS'
 						color='#67b1d6'
 						smaller={true}

--- a/src/components/position-description.tsx
+++ b/src/components/position-description.tsx
@@ -22,7 +22,13 @@ const PositionDescription: React.FC = () => {
 	}
 
 	// Return JSX
-	return <Container>{positionDescription}</Container>;
+	return (
+		<Container>
+			{positionDescription || (
+				<em>Select a position above to see its description.</em>
+			)}
+		</Container>
+	);
 };
 
 export default PositionDescription;

--- a/src/redux/reducer.ts
+++ b/src/redux/reducer.ts
@@ -4,7 +4,7 @@ import { AppState, SET_POSITION, SET_TENURE, ChoiceTypes } from './types';
 
 // Define initial state
 const initialState: AppState = {
-	position: data.fields[0].roles[0].levels[0].title,
+	position: undefined,
 	tenure: data.tenures[0],
 };
 

--- a/src/redux/types.ts
+++ b/src/redux/types.ts
@@ -1,6 +1,6 @@
 // Export initial state interface
 export interface AppState {
-	position: string;
+	position?: string;
 	tenure: string;
 }
 


### PR DESCRIPTION
This PR changes two things:

First, it defaults the position choice to `undefined` so that the user must select the position before seeing the salary. This looks like:

<img width="898" alt="Screen Shot 2022-05-26 at 3 48 00 PM" src="https://user-images.githubusercontent.com/3850064/170577503-b6911c28-604b-4577-8d36-bd636208fc26.png">

Second, it enables prefilling the position choice to a specific position via a `?position=` URL search param. This position must exactly match a valid position, otherwise, it won't have any effect.