### PR TITLE
Fix glitching rendering of drop shadow on Safari

### DIFF
--- a/src/components/container.tsx
+++ b/src/components/container.tsx
@@ -9,7 +9,9 @@ const Container = styled.div`
 	font-size: 1.2rem;
 	line-height: 1.5rem;
 	color: #000;
-	-webkit-transform: translateZ(0); // Prevents super glitchy rendering on Safari
+
+	// Prevents super glitchy rendering on Safari
+	-webkit-transform: translateZ(0);
 
 	&:nth-child(3n + 1) {
 		filter: drop-shadow(5px 5px 0px #acd561);

--- a/src/components/container.tsx
+++ b/src/components/container.tsx
@@ -9,6 +9,7 @@ const Container = styled.div`
 	font-size: 1.2rem;
 	line-height: 1.5rem;
 	color: #000;
+	-webkit-transform: translateZ(0); // Prevents super glitchy rendering on Safari
 
 	&:nth-child(3n + 1) {
 		filter: drop-shadow(5px 5px 0px #acd561);


### PR DESCRIPTION
On iOS and iPadOS, Safari renders the drop shadow incredibly glitchy. But, if you use `translateZ()`, it (I believe) causes the GPU to render the container and drop shadow, which immediately fixes the problem.

Before | After
--- | ---
![before](https://user-images.githubusercontent.com/3850064/177591900-0590d321-2024-4c6a-81b3-a6ce4dfcb0ac.jpg) | ![after](https://user-images.githubusercontent.com/3850064/177591925-63ed8bd6-f9eb-4a2b-a1b6-f0576d47b517.jpg)
