### PR TITLE
Remove role names + Place head of customer success into its own role

### DIFF
--- a/src/data.json
+++ b/src/data.json
@@ -14,7 +14,6 @@
 			"descriptor": "an engineer",
 			"roles": [
 				{
-					"name": "Front End Engineer",
 					"levels": [
 						{
 							"title": "Front End Engineer I",
@@ -49,7 +48,6 @@
 					]
 				},
 				{
-					"name": "Back End Engineer",
 					"levels": [
 						{
 							"title": "Back End Engineer I",
@@ -84,7 +82,6 @@
 					]
 				},
 				{
-					"name": "Mobile Engineer",
 					"levels": [
 						{
 							"title": "Mobile Engineer I",
@@ -119,7 +116,6 @@
 					]
 				},
 				{
-					"name": "DevOps Engineer",
 					"levels": [
 						{
 							"title": "DevOps Engineer I",
@@ -160,7 +156,6 @@
 			"descriptor": "in customer success",
 			"roles": [
 				{
-					"name": "Customer Success Champion",
 					"levels": [
 						{
 							"title": "Customer Success Champion I",
@@ -185,7 +180,11 @@
 							"description": "A lead customer success champion—the first step on the leadership track—is highly experienced and has a knack for producing great work in others. While being a strong individual contributor, they also have leadership responsibilities. Among other things, this includes reviewing the performance of those who report to them, assisting with hiring and training new team members, providing guidance, and ensuring team goals are achieved.",
 							"startingSalary": 60000,
 							"annualRaises": [0.05, 0.035, 0.03, 0.025, 0.02, 0.02]
-						},
+						}
+					]
+				},
+				{
+					"levels": [
 						{
 							"title": "Head of Customer Success",
 							"description": "A head of customer success is responsible for leading the customer success team for one company in the Sparksuite family. They have a wealth of customer success knowledge and experience, and are responsible for designing the systems and frameworks employed by their team. They track the overall team performance and set the bigger-picture goals for ensuring customers are as successful as possible using our product. Among other responsibilities, a head of customer success is responsible for making hiring decisions, working on special projects, helping navigate more complex customer inquiries, aggregating feedback received through customer success channels, and collaborating with other team heads.",
@@ -201,7 +200,6 @@
 			"descriptor": "in administration",
 			"roles": [
 				{
-					"name": "Office manager",
 					"levels": [
 						{
 							"title": "Office manager",


### PR DESCRIPTION
For better organization, and to improve maintainability, role names (which aren't used) have been removed, and the "head of customer success" position has been moved into its own role. These changes won't lead to any visible differences in the UI; they just improve the organization of the `data.json` file.