### PR TITLE
Replace “office manager” with “people ops generalist”

### DIFF
--- a/src/data.json
+++ b/src/data.json
@@ -240,6 +240,24 @@
 					]
 				}
 			]
+		},
+		{
+			"name": "People Ops",
+			"descriptor": "in people ops",
+			"roles": [
+				{
+					"levels": [
+						{
+							"title": "People Ops Generalist",
+							"description": "A people ops generalist is responsible for and passionate about creating an exceptional experience for current and prospective team members. Among a variety of responsibilities, they help attract and onboard talented team members by overseeing hiring, onboarding, and training; they promote our goals of transparency, clarity, and flexibility with our policies and benefits; they foster company culture by coordinating team outings, events, and activities; they ensure compliance with employment laws; and they support managers as they lead their teams. A people ops generalist has the knowledge and experience to accomplish these responsibilities and possesses the ability to communicate clearly and effectively.",
+							"startingSalary": 75000,
+							"annualRaises": [
+								0.05, 0.035, 0.03, 0.025, 0.02, 0.02, 0.015, 0.015
+							]
+						}
+					]
+				}
+			]
 		}
 	]
 }

--- a/src/data.json
+++ b/src/data.json
@@ -240,24 +240,6 @@
 					]
 				}
 			]
-		},
-		{
-			"name": "Administration",
-			"descriptor": "in administration",
-			"roles": [
-				{
-					"levels": [
-						{
-							"title": "Office manager",
-							"description": "An office manager is responsible for orchestrating the many facets of our office environment. They’re responsible for ensuring our team is equipped to work productively, fostering an enjoyable working experience, organizing team activities, assisting with planning and hosting events, and supporting team members in their day-to-day responsibilities.",
-							"startingSalary": 46500,
-							"annualRaises": [
-								0.075, 0.05, 0.03, 0.025, 0.02, 0.02, 0.015, 0.015
-							]
-						}
-					]
-				}
-			]
 		}
 	]
 }


### PR DESCRIPTION
As part of a broader project to split the “office manager” position into two separate positions, this PR replaces the “office manager” position with a new “people ops generalist” position.