### PR TITLE
Preserve state during HMR

### DIFF
--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -10,8 +10,20 @@ if (process.env.NODE_ENV === 'development') {
 	middlewares.push(logger);
 }
 
-// Create store
-const store = createStore(rootReducer, applyMiddleware(...middlewares));
+// Create store, restoring any state preserved across HMR update
+const store = createStore(
+	rootReducer,
+	module.hot?.data?.state,
+	applyMiddleware(...middlewares)
+);
+
+// Before this module is disposed during HMR update, save the current state
+//  -> That way, it can be restored when the module is re-evaluated above
+if (module.hot) {
+	module.hot.addDisposeHandler((data) => {
+		data.state = store.getState();
+	});
+}
 
 // Export
 export default store;


### PR DESCRIPTION
These changes help with local development by preserving Redux state during hot module reloads. Otherwise, HMR updates cause the front end to enter an unexpected state that requires manually reselecting some of the choices, which can be tedious.